### PR TITLE
Add DDS support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1160,6 +1160,120 @@ function basename(filename) {
 }
 
 // ─────────────────────────────────────────────
+//  NWN/Bioware DDS-Parser  (custom 20-Byte Header + DXT1/DXT5)
+//
+//  Bioware nutzt kein Standard-DDS. Eigener Header:
+//    [0-3]   uint32 Breite
+//    [4-7]   uint32 Höhe
+//    [8-11]  uint32 Mip-Hinweis (ignoriert)
+//    [12-15] uint32 Mip0-Größe  (w*h/2 = DXT1 | w*h = DXT5)
+//    [16-19] float  1.0 (ignoriert)
+//    [20+]   Rohe DXT1/DXT5-Blockdaten ohne weiteren Header
+// ─────────────────────────────────────────────
+function parseNWNDDS(buffer) {
+  const data = new Uint8Array(buffer);
+  if (data.length < 20) throw new Error('DDS: Datei zu kurz');
+
+  const w      = data[0]|(data[1]<<8)|(data[2]<<16)|(data[3]<<24);
+  const h      = data[4]|(data[5]<<8)|(data[6]<<16)|(data[7]<<24);
+  const mip0sz = data[12]|(data[13]<<8)|(data[14]<<16)|(data[15]<<24);
+
+  if (w<=0||h<=0||w>8192||h>8192) throw new Error('DDS: Ungültige Auflösung '+w+'x'+h);
+
+  const dxt1Exp = Math.max(1,Math.ceil(w/4))*Math.max(1,Math.ceil(h/4))*8;
+  const dxt5Exp = Math.max(1,Math.ceil(w/4))*Math.max(1,Math.ceil(h/4))*16;
+  let fmt = (mip0sz===dxt5Exp) ? 'DXT5' : 'DXT1';
+  if (mip0sz!==dxt1Exp && mip0sz!==dxt5Exp) {
+    fmt = ((data.length-20) >= dxt5Exp) ? 'DXT5' : 'DXT1';
+  }
+
+  const pixels  = new Uint8ClampedArray(w * h * 4);
+  const blocksX = Math.max(1, Math.ceil(w/4));
+  const blocksY = Math.max(1, Math.ceil(h/4));
+
+  function rgb565(v) {
+    return [((v>>11)&0x1F)*255/31|0, ((v>>5)&0x3F)*255/63|0, (v&0x1F)*255/31|0];
+  }
+
+  function decodeDXT1(src, bx, by) {
+    const c0=src[0]|(src[1]<<8), c1=src[2]|(src[3]<<8);
+    const [r0,g0,b0]=rgb565(c0), [r1,g1,b1]=rgb565(c1);
+    const cr=[r0,r1,0,0], cg=[g0,g1,0,0], cb=[b0,b1,0,0], ca=[255,255,255,255];
+    if (c0>c1) {
+      cr[2]=(2*r0+r1)/3|0; cg[2]=(2*g0+g1)/3|0; cb[2]=(2*b0+b1)/3|0;
+      cr[3]=(r0+2*r1)/3|0; cg[3]=(g0+2*g1)/3|0; cb[3]=(b0+2*b1)/3|0;
+    } else {
+      cr[2]=(r0+r1)/2|0; cg[2]=(g0+g1)/2|0; cb[2]=(b0+b1)/2|0;
+      cr[3]=0; cg[3]=0; cb[3]=0; ca[3]=0;
+    }
+    let idx=src[4]|(src[5]<<8)|(src[6]<<16)|(src[7]<<24);
+    for (let py=0;py<4;py++) for (let px=0;px<4;px++) {
+      const dx=bx*4+px, dy=by*4+py;
+      if (dx<w&&dy<h) {
+        const i=idx&3, p=(dy*w+dx)*4;
+        pixels[p]=cr[i]; pixels[p+1]=cg[i]; pixels[p+2]=cb[i]; pixels[p+3]=ca[i];
+      }
+      idx>>>=2;
+    }
+  }
+
+  function decodeDXT5Alpha(src) {
+    const a0=src[0],a1=src[1];
+    const av=[a0,a1,0,0,0,0,0,0];
+    if (a0>a1) { for(let i=2;i<8;i++) av[i]=((8-i)*a0+(i-1)*a1)/7|0; }
+    else { for(let i=2;i<6;i++) av[i]=((6-i)*a0+(i-1)*a1)/5|0; av[6]=0; av[7]=255; }
+    // 6-Byte 48-bit Indexfeld → 16 3-bit Indizes
+    const b=[src[2],src[3],src[4],src[5],src[6],src[7]];
+    const result=[];
+    let bit=0;
+    for(let i=0;i<16;i++) {
+      const byte_=Math.floor(bit/8), shift=bit%8;
+      let v=(b[byte_]>>shift);
+      if(shift>5) v|=(b[byte_+1]<<(8-shift));
+      result.push(av[v&7]);
+      bit+=3;
+    }
+    return result;
+  }
+
+  let off=20;
+  for (let by=0;by<blocksY;by++) for (let bx=0;bx<blocksX;bx++) {
+    if (fmt==='DXT5') {
+      const alphas=decodeDXT5Alpha(data.subarray(off,off+8));
+      decodeDXT1(data.subarray(off+8,off+16),bx,by);
+      for(let py=0;py<4;py++) for(let px=0;px<4;px++) {
+        const dx=bx*4+px,dy=by*4+py;
+        if(dx<w&&dy<h) pixels[(dy*w+dx)*4+3]=alphas[py*4+px];
+      }
+      off+=16;
+    } else {
+      decodeDXT1(data.subarray(off,off+8),bx,by);
+      off+=8;
+    }
+  }
+
+  // Zeilen vertikal spiegeln — identisch zu parseTGA.
+  // Mit flipY=false + 1-v UV-Transform erwartet Three.js canvas.row[0] = Bild-Unten.
+  // DXT1 speichert top-to-bottom → canvas.row[0] = Bild-Oben → muss gespiegelt werden.
+  const rowBytes = w * 4;
+  const tmp = new Uint8ClampedArray(rowBytes);
+  for (let row = 0; row < (h >> 1); row++) {
+    const top = row * rowBytes;
+    const bot = (h - 1 - row) * rowBytes;
+    tmp.set(pixels.subarray(top, top + rowBytes));
+    pixels.copyWithin(top, bot, bot + rowBytes);
+    pixels.set(tmp, bot);
+  }
+
+  const cvs=document.createElement('canvas');
+  cvs.width=w; cvs.height=h;
+  cvs.getContext('2d').putImageData(new ImageData(pixels,w,h),0,0);
+  const tex=new THREE.CanvasTexture(cvs);
+  tex.flipY=false; tex.needsUpdate=true;
+  return tex;
+}
+
+// ─────────────────────────────────────────────
 //  TGA-Parser  (Type 2 uncompressed + Type 10 RLE, 16/24/32 bit)
 // ─────────────────────────────────────────────
 function parseTGA(buffer) {
@@ -1413,6 +1527,23 @@ function loadFiles(fileList) {
           setStatus(fmt('status_tex_loaded', { name: file.name, n: texLoaded, total: texFiles.length }));
         } catch(err) {
           console.warn('TGA Fehler:', file.name, err.message);
+          setStatus(fmt('status_tga_error', { name: file.name, msg: err.message }));
+        }
+        texPending--;
+        if (texPending === 0) onAllTexReady();
+      };
+      reader.onerror = () => { texPending--; if (texPending === 0) onAllTexReady(); };
+      reader.readAsArrayBuffer(file);
+    } else if (ext === 'dds') {
+      // NWN/Bioware custom DDS (kein Standard-DDS-Header)
+      const reader = new FileReader();
+      reader.onload = ev => {
+        try {
+          textureCache[key] = parseNWNDDS(ev.target.result);
+          texLoaded++;
+          setStatus(fmt('status_tex_loaded', { name: file.name, n: texLoaded, total: texFiles.length }));
+        } catch(err) {
+          console.warn('DDS Fehler:', file.name, err.message);
           setStatus(fmt('status_tga_error', { name: file.name, msg: err.message }));
         }
         texPending--;


### PR DESCRIPTION
This will add DDS support for textures. The viewer will use TGA or DDS, so if you first load a MDL with it's TGA texture and afterwards add a DDS texture it will exchange those. Closes #11.