### PR TITLE
Fix Scene Graph and Set Browser compatibility issues

### DIFF
--- a/css/viewer.css
+++ b/css/viewer.css
@@ -1228,6 +1228,20 @@ input[type=number].ctrl-val:focus { border-color: var(--gold); }
 #set-browser-panel.sb-collapsed .sb-body,
 #set-browser-panel.sb-collapsed .sb-statusbar { display: none; }
 
+/* ── Set Browser: Watch Folder hint banner ── */
+#sb-watch-hint {
+  margin: 6px 8px 2px;
+  padding: 6px 10px;
+  background: rgba(var(--gold-rgb), 0.05);
+  border: 1px solid rgba(var(--gold-rgb), 0.2);
+  border-radius: 3px;
+  color: var(--amber);
+  font-size: 10px;
+  letter-spacing: 0.3px;
+  line-height: 1.5;
+  flex-shrink: 0;
+}
+
 /* ── Model Name Hint (below XYZ, when sidebar is collapsed) ── */
 #model-name-hint {
   position: absolute;

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
       <span data-i18n="drop_or">or click to open</span><br>
       <small style="color:var(--muted)" data-i18n="drop_hint">Multiple files at once supported</small>
     </div>
-    <input type="file" id="file-input" accept=".mdl,.tga,.dds,.plt,.mtr,.txi,.wok,.pwk,.dwk,.png,.jpg,.txt" multiple>
+    <input type="file" id="file-input" accept=".mdl,.tga,.dds,.plt,.mtr,.txi,.wok,.pwk,.dwk,.set,.png,.jpg,.txt" multiple>
 
     <div id="texture-status" style="margin:0 12px 8px;display:none;">
       <div id="texture-header" onclick="toggleTextureList()">

--- a/js/hot_reload.js
+++ b/js/hot_reload.js
@@ -629,6 +629,9 @@ const HotReload = (() => {
     getMDLHandle:   name => _watchedMDL.get(name.toLowerCase())?.handle ?? null,
     onWatchChange:  cb   => _watchChangeCallbacks.push(cb),
     onMDLChanged:   cb   => _mdlChangedCallbacks.push(cb),
+    // Returns true when the watcher is running and has found at least one file.
+    // Used by SetBrowser to show/hide the "Watch Folder required" hint banner.
+    isWatching:     ()   => _active && _watched.size > 0,
   };
 
 })();

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -218,6 +218,8 @@ const I18N_BUNDLE = {
     sb_load_error:        'Error loading tile model: {model} — {msg}',
     sb_group_loaded:      'Group loaded: {n} tiles',
     sb_group_empty:       'No tiles available in watch folder for this group',
+    sb_watch_hint:        'Activate "Watch Folder" in the sidebar to load tile models.',
+    sb_watch_unsupported: 'Watch Folder requires Chrome or Edge.',
   },
   de: {
     _meta: { language: 'Deutsch', code: 'de' },
@@ -426,6 +428,8 @@ const I18N_BUNDLE = {
     sb_load_error:        'Fehler beim Laden des Tile-Modells: {model} — {msg}',
     sb_group_loaded:      'Gruppe geladen: {n} Tiles',
     sb_group_empty:       'Keine Tiles der Gruppe im beobachteten Ordner verfügbar',
+    sb_watch_hint:        '„Ordner beobachten" in der Sidebar aktivieren, um Tile-Modelle zu laden.',
+    sb_watch_unsupported: 'Watch Folder erfordert Chrome oder Edge.',
   }
 };
 

--- a/js/loader.js
+++ b/js/loader.js
@@ -404,6 +404,44 @@ async function loadGroupFromHandles(entries, cols, rows) {
   modelGroup = rootGroup;
 
   if (loadedCount > 0) {
+    // ── Rebuild combined node list for all loaded tiles ───────────────────
+    // buildScene() calls buildNodeList() after each tile, which overwrites
+    // the sidebar list with only that tile's nodes. After the loop we rebuild
+    // it once from the fully accumulated nodeObjects so that the scene-graph
+    // toolbar buttons (All/None/type toggles) operate on every tile's nodes.
+    const allNodes = [];
+    let groupVerts = 0, groupFaces = 0;
+    for (const obj of Object.values(nodeObjects)) {
+      const nd = obj.userData && obj.userData.nodeData;
+      if (nd) {
+        allNodes.push(nd);
+        groupVerts += nd.verts ? nd.verts.length : 0;
+        groupFaces += nd.faces ? nd.faces.length : 0;
+      }
+    }
+
+    // Synthetic group model — only the fields consumed by buildNodeList()
+    // and showModelInfo() are required.
+    const groupModel = {
+      name:           fmt('sb_tile_count', { n: loadedCount }),
+      supermodel:     null,
+      classification: 'Tileset',
+      animCount:      0,
+      nodes:          allNodes,
+    };
+
+    // Replace currentModel so that getNeededTextures() / HotReload cover
+    // all tiles, not just the last one.
+    currentModel = groupModel;
+
+    buildNodeList(groupModel);
+    showModelInfo(groupModel, groupVerts, groupFaces);
+
+    // Update HUD stats to reflect the full group
+    document.getElementById('stat-verts').textContent = groupVerts.toLocaleString('de');
+    document.getElementById('stat-faces').textContent = groupFaces.toLocaleString('de');
+    document.getElementById('stat-nodes').textContent = allNodes.length;
+
     logInfoI18n('sb_group_loaded', { n: loadedCount });
     setStatus(fmt('sb_group_loaded', { n: loadedCount }));
   } else {

--- a/js/loader.js
+++ b/js/loader.js
@@ -9,6 +9,7 @@ function loadFiles(fileList) {
 
   const files    = Array.from(fileList);
   const mdlFiles = files.filter(f => f.name.toLowerCase().endsWith('.mdl') || f.name.toLowerCase().endsWith('.txt'));
+  const setFiles = files.filter(f => f.name.toLowerCase().endsWith('.set'));
   const texFiles = files.filter(f => /\.(tga|png|jpg|jpeg|dds|plt)$/i.test(f.name));
   const txiFiles = files.filter(f => /\.txi$/i.test(f.name));
   const mtrFiles = files.filter(f => /\.mtr$/i.test(f.name));
@@ -18,7 +19,7 @@ function loadFiles(fileList) {
 
   if (mdlFiles.length === 0 && texFiles.length === 0 && txiFiles.length === 0 
       && mtrFiles.length === 0 && wokFiles.length === 0 && pwkFiles.length === 0
-      && dwkFiles.length === 0) {
+      && dwkFiles.length === 0 && setFiles.length === 0) {
     setStatus(L('status_no_files'));
     return;
   }
@@ -152,6 +153,14 @@ function loadFiles(fileList) {
       }
     };
     reader.readAsText(file);
+  }
+
+  // ── .set Files → Set Browser ─────────────────────────────────────────
+  for (const file of setFiles) {
+    if (typeof SetBrowser !== 'undefined') {
+      SetBrowser.open();
+      SetBrowser.loadSetFile(file);
+    }
   }
 
   if (texPending === 0 && mtrPending === 0) {

--- a/js/scene.js
+++ b/js/scene.js
@@ -23,15 +23,20 @@ camera.position.set(2, 2, 4);
 camera.lookAt(0, 0, 0);
 
 // Lights, updates for r152
-const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
+// FIX: Reduced directional intensities to avoid over-bright specular peaks on
+// Phong-converted PBR materials. Ambient raised to compensate shadow-side darkness.
+// dirLight  1.4 → 0.9  (main sun: was too strong for corrected low-metalness mats)
+// dirLight2 0.6 → 0.4  (fill:    proportional reduction)
+// ambient   0.5 → 0.7  (raised so dark sides stay readable)
+const ambientLight = new THREE.AmbientLight(0xffffff, 0.7);
 scene.add(ambientLight);
 
-const dirLight = new THREE.DirectionalLight(0xfff0d0, 1.4);
+const dirLight = new THREE.DirectionalLight(0xfff0d0, 0.9);
 dirLight.position.set(5, 10, 8);
 dirLight.castShadow = true;
 scene.add(dirLight);
 
-const dirLight2 = new THREE.DirectionalLight(0xd0e0ff, 0.6);
+const dirLight2 = new THREE.DirectionalLight(0xd0e0ff, 0.4);
 dirLight2.position.set(-6, 3, -5);
 scene.add(dirLight2);
 
@@ -213,5 +218,45 @@ canvas.addEventListener('touchmove', e => {
   }
   e.preventDefault();
 }, { passive: false });
+
+// ─────────────────────────────────────────────
+//  Mesh Pick (Left Click → select node)
+// ─────────────────────────────────────────────
+const _pickRaycaster = new THREE.Raycaster();
+
+canvas.addEventListener('click', e => {
+  // Only when Ctrl or Cmd is pressed and a selection is made with the left mouse button.
+  if (!e.ctrlKey || e.metaKey) return;
+  if (!modelGroup) return;
+
+  const rect = canvas.getBoundingClientRect();
+  const ndc = new THREE.Vector2(
+    ((e.clientX - rect.left) / rect.width)  *  2 - 1,
+    ((e.clientY - rect.top)  / rect.height) * -2 + 1
+  );
+
+  _pickRaycaster.setFromCamera(ndc, camera);
+  const hits = _pickRaycaster.intersectObject(modelGroup, true);
+
+  for (const hit of hits) {
+    let obj = hit.object;
+
+    // Skip wireframe and backface children
+    if (obj.userData.isWireframe || obj.userData.isBackface || obj.userData.isAABB) continue;
+
+    // Skip emitter-preview-quads
+    if (obj.userData.isEmitterPreview) continue;
+
+    // Ascend to the named node (children of groups, etc.)
+    while (obj && !obj.name) obj = obj.parent;
+    if (!obj || !obj.name) continue;
+
+    // Select only nodes known to the scene graph
+    if (!nodeObjects[obj.name]) continue;
+
+    selectNode(obj.name);
+    return;
+  }
+});
 
 // ─────────────────────────────────────────────

--- a/js/scene_build.js
+++ b/js/scene_build.js
@@ -245,6 +245,28 @@ function buildScene(model) {
   // modelGroup/wireGroup/bboxHelper have already been cleared by clearSession().
   // (clearSession is called before every MDL load)
 
+  // ── Classification-based PBR limits ────────────────────────────────────
+  // NWN Phong specular values are additive colour, not physical reflectivity.
+  // Mapping them 1:1 to PBR metalness/roughness produces over-shiny surfaces,
+  // especially on Tileset, Door, Placeable and Effect models which almost never
+  // carry real metallic materials (those use dedicated MTR slots instead).
+  // Characters may have armour parts with slightly higher metalness.
+  //
+  // These limits apply only to the Phong→PBR fallback path (no MTR, no roughnessMap).
+  // When an MTR Roughness/Specularity parameter or a roughnessMap is present,
+  // the authored values are used directly and these limits are NOT applied.
+  const _cls = (model.classification || '').toLowerCase();
+  const _isTileOrEnv = _cls === 'tile' || _cls === 'door' ||
+                       _cls === 'placeable' || _cls === 'effect';
+  // FIX: Max metalness for non-authored (Phong-derived) path.
+  //   Tile/Door/Placeable/Effect → 0.12  (wood, stone, plaster: near-zero metalness)
+  //   Character / other          → 0.30  (may have armour, still capped below 0.35)
+  const _maxMetalness    = _isTileOrEnv ? 0.12 : 0.30;
+  // FIX: Roughness floor for non-authored path.
+  //   Tile/Door/Placeable/Effect → 0.60  (weathered surfaces should be matte)
+  //   Character / other          → 0.40  (skin, leather can be smoother)
+  const _roughnessFloor  = _isTileOrEnv ? 0.60 : 0.40;
+
   modelGroup = new THREE.Group();
 
   // NWN uses a Z-up coordinate system, Three.js expects Y-up.
@@ -463,16 +485,27 @@ function buildScene(model) {
       // Roughness + Metalness:
       // If roughnessMap is present → scalar = multiplier (1.0 = map has full effect).
       // If no roughnessMap → convert from MDL Phong values.
-      // MTR Roughness parameter overwrites both if explicitly set.
+      // MTR Roughness/Specularity parameters overwrite the fallback if explicitly set.
+      //
+      // FIX: The original Phong→PBR conversion over-estimated both metalness and
+      // specularity for typical NWN geometry:
+      //   • specMax * 1.5, capped at 0.6 → produced metalness 0.4–0.6 for normal meshes.
+      //     In PBR, non-metallic surfaces (wood, stone, plaster) must stay below 0.04.
+      //     We now use * 0.5 and cap at _maxMetalness (class-dependent: 0.12 or 0.30).
+      //   • shininess / 64.0 → roughness curve was too steep; shininess=32 gave 0.50
+      //     (visually glassy). Dividing by 128 and raising the floor via _roughnessFloor
+      //     maps typical NWN values (16–64) to roughness 0.65–0.88 instead of 0.25–0.75.
+      //   • MTR Specularity scalar was multiplied by 0.4 before; now 0.2 to match the
+      //     reduced non-authored path.
       const roughness = roughTex
         ? (mtrRoughParam !== null ? mtrRoughParam : 1.0)
         : (mtrRoughParam !== null
             ? mtrRoughParam
-            : Math.max(0.1, 1.0 - Math.min(node.shininess / 64.0, 0.9)));
+            : Math.max(_roughnessFloor, 1.0 - Math.min(node.shininess / 128.0, 0.40)));
       const specMax   = Math.max(node.specular[0], node.specular[1], node.specular[2]);
       const metalness = mtrSpecParam !== null
-        ? Math.min(mtrSpecParam * 0.4, 0.6)
-        : Math.min(specMax * 1.5, 0.6);
+        ? Math.min(mtrSpecParam * 0.2, _maxMetalness)
+        : Math.min(specMax * 0.5, _maxMetalness);
         
       // NWN uses back-face culling; DoubleSide only for alpha-blended materials
       // (magic effects, glass) that may legitimately show both faces.

--- a/js/setbrowser.js
+++ b/js/setbrowser.js
@@ -342,6 +342,24 @@ const SetBrowser = (() => {
   function _refreshAvailability() {
     if (!_setData) return;
 
+    // ── Watch Folder hint banner ─────────────────────────────────────
+    const hintEl = document.getElementById('sb-watch-hint');
+    if (hintEl) {
+      const backend     = typeof HotReload !== 'undefined' ? HotReload.getBackend() : null;
+      const watching    = typeof HotReload !== 'undefined' && HotReload.isWatching();
+      if (!backend) {
+        // Browser does not support File System Access API (Firefox etc.)
+        hintEl.textContent = L('sb_watch_unsupported');
+        hintEl.style.display = 'block';
+      } else if (!watching) {
+        // Supported but not yet active → prompt user to click Watch Folder
+        hintEl.textContent = L('sb_watch_hint');
+        hintEl.style.display = 'block';
+      } else {
+        hintEl.style.display = 'none';
+      }
+    }
+
     const canQuery = typeof HotReload !== 'undefined' &&
                      typeof HotReload.getMDLHandle === 'function';
 
@@ -604,6 +622,12 @@ const SetBrowser = (() => {
     toolbar.appendChild(groupSel);
 
     panel.appendChild(toolbar);
+
+    // ── Watch Folder hint (shown when no watcher is active) ──────
+    const watchHint = document.createElement('div');
+    watchHint.id = 'sb-watch-hint';
+    watchHint.style.display = 'none';   // _refreshAvailability() controls visibility
+    panel.appendChild(watchHint);
 
     // ── Tile container (scrollbar) ───────────────────────────
     const body = document.createElement('div');

--- a/lang/de.json
+++ b/lang/de.json
@@ -234,5 +234,7 @@
   "sb_read_error": "Fehler beim Lesen der .set-Datei: {name} — {msg}",
   "sb_load_error": "Fehler beim Laden des Tile-Modells: {model} — {msg}",
   "sb_group_loaded": "Gruppe geladen: {n} Tiles",
-  "sb_group_empty": "Keine Tiles der Gruppe im beobachteten Ordner verfügbar"
+  "sb_group_empty": "Keine Tiles der Gruppe im beobachteten Ordner verfügbar",
+  "sb_watch_hint": "'Ordner beobachten' in der Sidebar aktivieren, um Tile-Modelle zu laden.",
+  "sb_watch_unsupported": "Watch Folder erfordert Chrome oder Edge."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -234,5 +234,7 @@
   "sb_read_error": "Error reading .set file: {name} — {msg}",
   "sb_load_error": "Error loading tile model: {model} — {msg}",
   "sb_group_loaded": "Group loaded: {n} tiles",
-  "sb_group_empty": "No tiles available in watch folder for this group"
+  "sb_group_empty": "No tiles available in watch folder for this group",
+  "sb_watch_hint": "Activate 'Watch Folder' in the sidebar to load tile models.",
+  "sb_watch_unsupported": "Watch Folder requires Chrome or Edge."
 }


### PR DESCRIPTION
This will fix the issues with the set browser and the scene graph compatibility. And some more shinyness problems on non-mtr'ed textures. Closes #157 

In addition, the set file can now be loaded either via drag-and-drop or the "Open" function. Additional notifications have been added for this scenario.