### PR TITLE
V182 emitter representation

### DIFF
--- a/js/emitter.js
+++ b/js/emitter.js
@@ -318,7 +318,11 @@ class NWNEmitter {
     this.active      = [];    // currently living particles
     this.accumulator = 0;     // spawn time accumulator
     this.baseTex     = textureCache[node.emitterTexture] || null;
+    // Placeholder marker shown at the emitter position when no texture is loaded yet.
+    // Managed entirely within emitter.js — see _syncPlaceholder().
+    this._placeholder = null;
     this._buildPool();
+    this._syncPlaceholder();
   }
 
   _buildPool() {
@@ -350,7 +354,64 @@ class NWNEmitter {
       this._disposeParticles();
       this.baseTex = tex;
       this._buildPool();
+      // Texture arrived → hide placeholder, particles take over
+      this._syncPlaceholder();
     }
+  }
+
+  // ─────────────────────────────────────────────
+  //  Placeholder marker (visible when baseTex is null)
+  // ─────────────────────────────────────────────
+
+  /**
+   * Central switch: builds or shows/hides the placeholder depending on
+   * whether a texture is available. Called from constructor and refreshTexture().
+   */
+  _syncPlaceholder() {
+    if (!this.baseTex) {
+      // No texture → ensure placeholder exists and is visible
+      if (!this._placeholder) this._buildPlaceholder();
+      if (this._placeholder) this._placeholder.visible = true;
+    } else {
+      // Texture loaded → hide placeholder (particles take over)
+      if (this._placeholder) this._placeholder.visible = false;
+    }
+  }
+
+  /**
+   * Builds a small marker (tiny sphere + halo ring) in the emitter's colorStart
+   * and attaches it as a child of the emitter's scene node so it inherits
+   * position, orientation, and animation transforms automatically.
+   */
+  _buildPlaceholder() {
+    const nodeObj = nodeObjects[this.node.name];
+    if (!nodeObj) return;
+
+    // Derive marker colour from colorStart (same logic as scene_build.js emitColor)
+    const cs  = this.node.colorStart || [1, 0.6, 0.1];
+    const lum = cs[0] * 0.299 + cs[1] * 0.587 + cs[2] * 0.114;
+    const color = lum < 0.05
+      ? new THREE.Color(0xf0a030)
+      : new THREE.Color(cs[0], cs[1], cs[2]);
+
+    const grp = new THREE.Group();
+    grp.userData.isEmitterPlaceholder = true;
+
+    // Tiny centre sphere — marks the exact emitter origin
+    const sGeo = new THREE.SphereGeometry(0.015, 6, 4);
+    const sMat = new THREE.MeshBasicMaterial({ color });
+    grp.add(new THREE.Mesh(sGeo, sMat));
+
+    // Small halo ring — gives size reference and makes the marker recognisable
+    // rotation.x = π/2 matches the ring orientation used in scene_build.js
+    const rGeo = new THREE.TorusGeometry(0.05, 0.003, 6, 16);
+    const rMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.9 });
+    const ring = new THREE.Mesh(rGeo, rMat);
+    ring.rotation.x = Math.PI / 2;
+    grp.add(ring);
+
+    nodeObj.add(grp);
+    this._placeholder = grp;
   }
 
   /** Query world position of the emitter node */
@@ -456,6 +517,16 @@ class NWNEmitter {
   /** Release all GPU resources and remove sprites from the scene */
   dispose() {
     this._disposeParticles();
+    // Remove placeholder marker from its parent node and free GPU resources
+    if (this._placeholder) {
+      const nodeObj = nodeObjects[this.node.name];
+      if (nodeObj) nodeObj.remove(this._placeholder);
+      this._placeholder.traverse(child => {
+        if (child.geometry) child.geometry.dispose();
+        if (child.material) child.material.dispose();
+      });
+      this._placeholder = null;
+    }
     this.baseTex = null;
   }
 }

--- a/js/parser.js
+++ b/js/parser.js
@@ -110,7 +110,7 @@ function parseFullAnimNode(lines, start) {
     birthrate: 1, velocity: 1, randvel: 1, spread: 1,
     grav: 1, drag: 1, fps: 1, mass: 1, lifeexp: 1, particlerot: 1,
     alphastart: 1, alphamid: 1, alphaend: 1,
-    sizestart: 1, sizemid: 1, sizeend: 1,
+    sizestart: 1, sizemid: 0, sizeend: 1,
     colorstart: 3, colormid: 3, colorend: 3,
   };
 
@@ -256,7 +256,7 @@ function parseNode(lines, start) {
     xsize: 0, ysize: 0,   // Emitter area in cm (spawn spread area)
     alphaStart: 1, alphaMid: 1, alphaEnd: 0,
     colorStart: [1,1,1], colorMid: [1,1,1], colorEnd: [1,1,1],
-    sizeStart: 1, sizeMid: 1, sizeEnd: 1,
+    sizeStart: 1, sizeMid: 0, sizeEnd: 1,
     birthrate:  0,
     lifeExp:    1,
     mass:       0,

--- a/js/scene_build.js
+++ b/js/scene_build.js
@@ -717,16 +717,15 @@ function buildScene(model) {
 
       // Decoration visibility strategy:
       //   markerActive + texture already in cache → particles start immediately
-      //     → hide decoration so nothing obscures the effect
-      //   markerActive + texture not yet loaded   → show at 50% as position placeholder;
-      //     session.js hides them once the texture arrives (applyTexturesToScene)
+      //     → hide decoration and quad (particles take over)
+      //   markerActive + texture not yet loaded   → show decoration at full opacity +
+      //     colored placeholder quad; both hidden once texture arrives (session.js)
       //   !markerActive (no birthrate / no texture) → show at full opacity
-      const decorVisible = !markerActive || emTex === null;
-      const decorOpacity = markerActive ? 0.5 : 1.0;
+      const decorVisible = !markerActive;
 
       // Center: Sphere — r reduced from 0.06 → 0.04
       const sGeo = new THREE.SphereGeometry(0.04, 8, 6);
-      const sMat = new THREE.MeshBasicMaterial({ color: emitColor, transparent: markerActive, opacity: decorOpacity });
+      const sMat = new THREE.MeshBasicMaterial({ color: emitColor });
       const sphereMesh = new THREE.Mesh(sGeo, sMat);
       sphereMesh.userData.isEmitterDecoration = true;
       sphereMesh.visible = decorVisible;
@@ -734,7 +733,7 @@ function buildScene(model) {
 
       // Ring in XZ plane — r reduced 0.15 → 0.10, tube 0.012 → 0.008
       const rGeo = new THREE.TorusGeometry(0.10, 0.008, 6, 20);
-      const rMat = new THREE.MeshBasicMaterial({ color: emitColor, transparent: true, opacity: 0.75 * decorOpacity });
+      const rMat = new THREE.MeshBasicMaterial({ color: emitColor, transparent: true, opacity: 0.75 });
       const ring = new THREE.Mesh(rGeo, rMat);
       ring.rotation.x = Math.PI / 2;
       ring.userData.isEmitterDecoration = true;
@@ -754,7 +753,7 @@ function buildScene(model) {
       ]);
       const aGeo = new THREE.BufferGeometry();
       aGeo.setAttribute('position', new THREE.Float32BufferAttribute(arrowPts, 3));
-      const aMat = new THREE.LineBasicMaterial({ color: emitColor, transparent: true, opacity: 0.85 * decorOpacity });
+      const aMat = new THREE.LineBasicMaterial({ color: emitColor, transparent: true, opacity: 0.85 });
       const arrowLines = new THREE.LineSegments(aGeo, aMat);
       arrowLines.userData.isEmitterDecoration = true;
       arrowLines.visible = decorVisible;
@@ -774,10 +773,10 @@ function buildScene(model) {
         alphaTest:   0.05,
         color:       emTex ? 0xffffff : emitColor,
         map:         emTex || null,
-        opacity:     emTex ? 1.0 : 0.0,   // invisible until texture arrives
+        opacity:     emTex ? 1.0 : 0.0,
       });
       if ((node.blend || '').toLowerCase() === 'additive') {
-        qMat.blending = THREE.AdditiveBlending;
+        qMat.blending  = THREE.AdditiveBlending;
         qMat.alphaTest = 0;
       }
       const quad = new THREE.Mesh(qGeo, qMat);
@@ -785,14 +784,15 @@ function buildScene(model) {
       quad.userData.isEmitterPreview  = true;
       quad.userData.emitterTexName    = emTexName;
       quad.userData.emitterBlend      = (node.blend || '').toLowerCase();
-      // Hide preview quad when the particle emitter is active —
-      // emitter.js will take over the display then.
+      // Active emitter + texture already loaded → hide quad (particles take over).
+      // Active emitter + texture missing        → hide quad (emitter.js shows placeholder).
+      // Inactive emitter                        → show quad (texture preview or empty).
       quad.visible = !markerActive;
       group.add(quad);
 
       // userData on the group object for applyTexturesToScene
-      group.userData.hasEmitterPreview = true;
-      group.userData.emitterTexName    = emTexName;
+      group.userData.hasEmitterPreview    = true;
+      group.userData.emitterTexName       = emTexName;
 
       obj = group;
 

--- a/js/scene_build.js
+++ b/js/scene_build.js
@@ -704,50 +704,66 @@ function buildScene(model) {
         ? new THREE.Color(0xf0a030)
         : new THREE.Color(cs[0], cs[1], cs[2]);
 
-      // Marker opacity: 50% if the emitter is active (particles take over the display),
-      // otherwise full opacity as a placeholder indicator.
       // An emitter is considered active if either static birthrate > 0 OR
       // birthratekey is present in an animation.
       const hasAnimBirthrate = (model.animations || []).some(
         anim => (anim.nodes[node.name]?.emitterKeys?.birthrate?.length ?? 0) > 0
       );
       const markerActive = (node.birthrate > 0 || hasAnimBirthrate) && node.emitterTexture;
-      const markerOpacity = markerActive ? 0.5 : 1.0;
 
-      // Center: Sphere
-      const sGeo = new THREE.SphereGeometry(0.06, 8, 6);
-      const sMat = new THREE.MeshBasicMaterial({ color: emitColor, transparent: markerActive, opacity: markerOpacity });
-      group.add(new THREE.Mesh(sGeo, sMat));
+      // Resolve texture now — needed to decide decoration visibility below.
+      const emTexName = node.emitterTexture || null;
+      const emTex     = emTexName ? textureCache[emTexName] : null;
 
-      // Ring in XZ plane (horizontal after rotation = emitter opening)
-      const rGeo = new THREE.TorusGeometry(0.15, 0.012, 6, 20);
-      const rMat = new THREE.MeshBasicMaterial({ color: emitColor, transparent: true, opacity: 0.75 * markerOpacity });
+      // Decoration visibility strategy:
+      //   markerActive + texture already in cache → particles start immediately
+      //     → hide decoration so nothing obscures the effect
+      //   markerActive + texture not yet loaded   → show at 50% as position placeholder;
+      //     session.js hides them once the texture arrives (applyTexturesToScene)
+      //   !markerActive (no birthrate / no texture) → show at full opacity
+      const decorVisible = !markerActive || emTex === null;
+      const decorOpacity = markerActive ? 0.5 : 1.0;
+
+      // Center: Sphere — r reduced from 0.06 → 0.04
+      const sGeo = new THREE.SphereGeometry(0.04, 8, 6);
+      const sMat = new THREE.MeshBasicMaterial({ color: emitColor, transparent: markerActive, opacity: decorOpacity });
+      const sphereMesh = new THREE.Mesh(sGeo, sMat);
+      sphereMesh.userData.isEmitterDecoration = true;
+      sphereMesh.visible = decorVisible;
+      group.add(sphereMesh);
+
+      // Ring in XZ plane — r reduced 0.15 → 0.10, tube 0.012 → 0.008
+      const rGeo = new THREE.TorusGeometry(0.10, 0.008, 6, 20);
+      const rMat = new THREE.MeshBasicMaterial({ color: emitColor, transparent: true, opacity: 0.75 * decorOpacity });
       const ring = new THREE.Mesh(rGeo, rMat);
       ring.rotation.x = Math.PI / 2;
+      ring.userData.isEmitterDecoration = true;
+      ring.visible = decorVisible;
       group.add(ring);
 
-      // Direction arrows: local -Z → world +Y (up) after modelGroup rotation
+      // Direction arrows — scaled ~30% smaller (reach 0.22 → 0.16)
       const arrowPts = new Float32Array([
         // Center ray
-         0,    0,  0,       0,    0,  -0.22,
+         0,    0,  0,       0,    0,  -0.16,
         // Arrowhead legs
-        -0.06, 0, -0.14,    0,    0,  -0.22,
-         0.06, 0, -0.14,    0,    0,  -0.22,
+        -0.04, 0, -0.10,    0,    0,  -0.16,
+         0.04, 0, -0.10,    0,    0,  -0.16,
         // Side rays (indicate spread)
-        -0.12, 0,  0,      -0.08, 0,  -0.16,
-         0.12, 0,  0,       0.08, 0,  -0.16,
+        -0.08, 0,  0,      -0.06, 0,  -0.11,
+         0.08, 0,  0,       0.06, 0,  -0.11,
       ]);
       const aGeo = new THREE.BufferGeometry();
       aGeo.setAttribute('position', new THREE.Float32BufferAttribute(arrowPts, 3));
-      const aMat = new THREE.LineBasicMaterial({ color: emitColor, transparent: true, opacity: 0.85 * markerOpacity });
-      group.add(new THREE.LineSegments(aGeo, aMat));
+      const aMat = new THREE.LineBasicMaterial({ color: emitColor, transparent: true, opacity: 0.85 * decorOpacity });
+      const arrowLines = new THREE.LineSegments(aGeo, aMat);
+      arrowLines.userData.isEmitterDecoration = true;
+      arrowLines.visible = decorVisible;
+      group.add(arrowLines);
 
       // ── Texture Preview Quad ───────────────────────────────────────────
       // PlaneGeometry has normal = local +Z.
       // rotation.x = +π/2 rotates the normal to local -Y.
       // After modelGroup rotation: local -Y → world +Z (towards camera) → visible.
-      const emTexName = node.emitterTexture || null;
-      const emTex     = emTexName ? textureCache[emTexName] : null;
       // Size from sizeStart, minimum size 0.15
       const qSize = Math.max(node.sizeStart || 0.5, 0.15);
       const qGeo  = new THREE.PlaneGeometry(qSize, qSize);

--- a/js/session.js
+++ b/js/session.js
@@ -124,7 +124,6 @@ function clearSession(keepTextures = false) {
   animState.playing  = false;
   animState.time     = 0;
   if (typeof txiWallTime !== 'undefined') txiWallTime = 0;
-  if (typeof danglyWallTime !== 'undefined') danglyWallTime = 0;
   geometryPose       = {};
   document.getElementById('anim-panel').style.display = 'none';
   const animBody  = document.getElementById('anim-body');
@@ -445,8 +444,14 @@ function applyTexturesToScene() {
     const texName = node.emitterTexture;
     if (!texName || !textureCache[texName]) continue;
     const tex = textureCache[texName];
-    // Find preview quad mesh inside the emitter group
+    // Update preview quad and hide decoration markers now that particles take over.
     obj.traverse(child => {
+      // FIX: Decoration (sphere / ring / arrows) was shown at 50% as placeholder
+      // while the texture was still missing. Now that the texture has arrived,
+      // hide it completely so it doesn't obscure the particle effect.
+      if (child.userData.isEmitterDecoration) {
+        child.visible = false;
+      }
       if (child.userData.isEmitterPreview && child.material) {
         child.material.map     = tex;
         child.material.color.set(0xffffff);

--- a/js/session.js
+++ b/js/session.js
@@ -446,14 +446,13 @@ function applyTexturesToScene() {
     const tex = textureCache[texName];
     // Update preview quad and hide decoration markers now that particles take over.
     obj.traverse(child => {
-      // FIX: Decoration (sphere / ring / arrows) was shown at 50% as placeholder
-      // while the texture was still missing. Now that the texture has arrived,
-      // hide it completely so it doesn't obscure the particle effect.
+      // Decoration (sphere / ring / arrows) was shown as placeholder while the
+      // texture was missing. Hide it now that particles have taken over.
       if (child.userData.isEmitterDecoration) {
         child.visible = false;
       }
       if (child.userData.isEmitterPreview && child.material) {
-        child.material.map     = tex;
+        child.material.map   = tex;
         child.material.color.set(0xffffff);
         child.material.opacity = 1.0;
         if (child.userData.emitterBlend === 'additive') {


### PR DESCRIPTION
This updates the display of emitters in the viewer. The marker indicating an emitter's presence in the model is now smaller and is hidden as soon as the corresponding texture is loaded.
Additionally, the default mid-point initial value (sizemid) for emitters has been reduced to 0.

Closes #170 