### PR TITLE
c183 sb node name convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ No installation, no server — just open `index.html` locally or use it directly
 - **Sprite-sheet UV animation** — UV tiling and orientation (TGA flip-Y / `flipY=false` compatible); `xgrid`/`ygrid` support
 - **Keyframe-driven birthrate** — Emitter birthrate follows animation keyframe curves (`birthratekey`)
 - **Billboard modes** — Standard camera-facing sprites and `Billboard_to_World_Z` flat-ground particles
+- **Smart decoration visibility** — The in-scene emitter marker (sphere, ring, directional arrows) is automatically hidden once the emitter is active and its texture is loaded; visible only as a placeholder when the texture has not yet arrived or the emitter has no birthrate
 
 ### Textures & Materials
 - **Texture formats** — TGA (Types 2, 3, 10, 11 — 16/24/32-bit), DDS (DXT1, DXT3, DXT5, Bioware custom, standard), PNG, JPG; ATI1/BC4 and ATI2/BC5 for NWN:EE specular and normal maps
@@ -94,13 +95,14 @@ No installation, no server — just open `index.html` locally or use it directly
 - **Tileset (.set) parser** — Reads NWN INI-format `.set` files (tile definitions, group layouts, terrain corners)
 - **Tile browser** — Searchable, filterable floating panel (grid and list view); free-text and group filter
 - **Click-to-load** — Clicking an available tile loads its MDL instantly via the watch folder handle
-- **Group view** — Loads all tiles of a group side-by-side in a NWN-standard 10 m × 10 m grid
+- **Group view** — Loads all tiles of a group side-by-side in a NWN-standard 10 m × 10 m grid; the scene graph and model-info panel reflect all tiles combined (aggregate node list, total vertex/face counts)
 - **Change indicator** — Active tile gets a ↻ badge when its MDL changes on disk
 
 ### Scene Graph & Inspection
 - **Node hierarchy** — Scene graph in the sidebar, collapsible
 - **Per-node visibility** — Toggle individual nodes via ⬡ / ● icon
 - **Type filter toolbar** — One-click bulk toggle for MESH / SKIN / DUMMY / EMIT / LIGHT / AABB / DANG
+- **Collision-safe visibility** — In group-loaded tileset scenes, multiple tiles may share identical node names (e.g. `walkmesh` on AABB nodes, or generic mesh names like `ground01`). Each scene graph entry correctly controls its own specific Three.js object regardless of name collisions — visibility toggles and type-filter buttons all resolve to the right tile.
 - **Node Inspector** — Draggable floating panel with zoom controls (−/○/＋); shows: type, parent, vertices, faces, bitmap, position, diffuse, alpha, plus type-specific sections for emitter nodes (all parameters), light nodes (color, radius, multiplier, shadow, etc.), and MTR nodes (slot status, renderhint, tangent status, shader parameters)
 - **Skeleton Helper** — Three.js SkeletonHelper overlay for skinned models; toggled via the Skeleton button
 
@@ -404,6 +406,14 @@ Multi-part character models (chest, head, legs, …) require all body parts **an
 ### Set Browser / Hot-Reload button is greyed out
 
 These features rely on the [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API), which is currently only available in **Chrome and Edge**. Firefox does not support this API. The rest of the viewer (MDL rendering, textures, animations, PLT) works in all modern browsers.
+
+---
+
+### Set Browser group view: toggling a node only affects one tile
+
+**Symptom:** In a group scene, multiple tiles share the same node name (e.g. `walkmesh` on AABB nodes, or generic mesh names like `ground01`). Clicking the visibility toggle in the scene graph appears to only affect one tile.
+
+**Status: fixed.** The viewer stores a direct Three.js object reference on each scene graph entry at load time, so visibility controls always resolve to the correct per-tile object regardless of name collisions. If you encounter this with an older build, update to the latest release.
 
 ---
 

--- a/js/scene_build.js
+++ b/js/scene_build.js
@@ -871,6 +871,14 @@ function buildScene(model) {
     obj.userData.nodeData = node;
     obj.isBone = true; // NEW: Strictly required for the SkeletonHelper to recognize the hierarchy
 
+    // FIX (AABB / duplicate-name collision):
+    // Store a direct back-reference on the parsed node data so that buildNodeList()
+    // can attach it to each .node-item element as _nwnObj.  This allows visibility
+    // toggles and type-filter buttons to resolve the *specific* Three.js object for
+    // this node without relying on nodeObjects[node.name], which only keeps the last
+    // writer when multiple tiles share the same node name (e.g. "walkmesh" in AABB).
+    node._threeObj = obj;
+
     objects[node.name] = obj;
     nodeObjects[node.name] = obj;
   }

--- a/js/ui.js
+++ b/js/ui.js
@@ -28,6 +28,12 @@ function buildNodeList(model) {
     item.className = 'node-item';
     item.dataset.name = node.name;
 
+    // FIX: Direct Three.js object reference for collision-safe visibility toggling.
+    // nodeObjects[node.name] only holds the *last* writer when multiple tiles share
+    // the same node name (e.g. "walkmesh").  _nwnObj always points to *this* node's
+    // specific object regardless of name collisions in the group scene.
+    item._nwnObj = node._threeObj || null;
+
     const typeClass = ['trimesh','skin','dummy','emitter','aabb','danglymesh'].includes(node.type) ? node.type : 'other';
     const dot = document.createElement('div');
     dot.className = `node-dot dot-${typeClass}`;
@@ -50,8 +56,10 @@ function buildNodeList(model) {
       vis.title = L('vis_toggle_title');
       vis.onclick = (e) => { e.stopPropagation(); toggleNodeVisibility(node.name, item, vis); };
       item.appendChild(vis);
-    } else if (nodeObjects[node.name]) {
-      // All other visible nodes (dummy, emitter, light …) are also toggleable
+    } else if (node._threeObj || nodeObjects[node.name]) {
+      // All other visible nodes (dummy, emitter, light …) are also toggleable.
+      // Use node._threeObj as the primary check so that nodes from non-last tiles
+      // (whose nodeObjects entry was overwritten) still receive a toggle button.
       const vis = document.createElement('span');
       vis.className = 'vis-toggle';
       vis.textContent = '●';
@@ -66,7 +74,10 @@ function buildNodeList(model) {
 }
 
 function toggleNodeVisibility(name, item, btn, visibleIcon) {
-  const obj = nodeObjects[name];
+  // FIX: Prefer the direct Three.js reference stored on the DOM element.
+  // nodeObjects[name] only holds the last tile's object when multiple tiles share
+  // the same node name.  item._nwnObj always points to the correct specific object.
+  const obj = item._nwnObj || nodeObjects[name];
   if (!obj) return;
   obj.visible = !obj.visible;
   item.classList.toggle('hidden', !obj.visible);
@@ -84,7 +95,7 @@ function toggleNodeVisibility(name, item, btn, visibleIcon) {
 function nodeVisAll(show) {
   document.querySelectorAll('.node-item').forEach(item => {
     const name = item.dataset.name;
-    const obj  = nodeObjects[name];
+    const obj  = item._nwnObj || nodeObjects[name];
     if (!obj) return;
     obj.visible = show;
     item.classList.toggle('hidden', !show);
@@ -101,8 +112,7 @@ function nodeVisAll(show) {
 // If all are visible → hide all; otherwise → show all
 function nodeVisToggleType(type) {
   const items = [...document.querySelectorAll(`.node-item`)].filter(el => {
-    const name = el.dataset.name;
-    const obj  = nodeObjects[name];
+    const obj  = el._nwnObj || nodeObjects[el.dataset.name];
     // Type via userData.nodeData.type, fallback via badge text
     if (!obj) return false;
     const nodeType = (obj.userData.nodeData?.type || '').toLowerCase();
@@ -111,14 +121,13 @@ function nodeVisToggleType(type) {
   if (items.length === 0) return;
 
   const allVisible = items.every(el => {
-    const obj = nodeObjects[el.dataset.name];
+    const obj = el._nwnObj || nodeObjects[el.dataset.name];
     return obj && obj.visible;
   });
   const show = !allVisible;   // if all visible → hide, otherwise → show
 
   items.forEach(item => {
-    const name = item.dataset.name;
-    const obj  = nodeObjects[name];
+    const obj  = item._nwnObj || nodeObjects[item.dataset.name];
     if (!obj) return;
     obj.visible = show;
     item.classList.toggle('hidden', !show);
@@ -140,7 +149,7 @@ function nodeVisUpdateTypeButtons() {
     if (btn.disabled) return;
     const type = btn.dataset.type;
     const anyVisible = [...document.querySelectorAll('.node-item')].some(el => {
-      const obj = nodeObjects[el.dataset.name];
+      const obj = el._nwnObj || nodeObjects[el.dataset.name];
       const nodeType = (obj?.userData.nodeData?.type || '').toLowerCase();
       return nodeType === type && obj?.visible;
     });


### PR DESCRIPTION
This implements a protection mechanism in the Set Browser that ensures, when multiple models containing nodes with identical names are loaded, these nodes are listed separately internally while remaining unchanged in the scene graph. Closes #171 