### PR TITLE
v184 bugfixes and code simplifications

### DIFF
--- a/js/animation.js
+++ b/js/animation.js
@@ -207,13 +207,31 @@ function resetToPose() {
 // All matrices and positions in NWN space (before modelGroup -90° X rotation).
 // The modelGroup rotation is applied to the skin mesh automatically by Three.js.
 const _sk = {
-  mgInv:    new THREE.Matrix4(),
-  boneMat:  new THREE.Matrix4(),
-  skinMat:  new THREE.Matrix4(),
-  vBind:    new THREE.Vector3(),
-  vTmp:     new THREE.Vector3(),
-  vFinal:   new THREE.Vector3(),
+  mgInv:   new THREE.Matrix4(),
+  boneMat: new THREE.Matrix4(),
+  vBind:   new THREE.Vector3(),
+  vTmp:    new THREE.Vector3(),
+  vFinal:  new THREE.Vector3(),
 };
+
+// Bone-Name → finale Skin-Matrix (NWN-Space), pro Frame neu befüllt.
+// ponytail: Map wird jeden Frame neu angelegt statt gepoolt — bei ~30-60
+// Bones ist die Allokation vernachlässigbar gegen die eingesparten
+// Matrix-Multiplikationen. Falls GC-Druck je messbar wird: persistenten
+// Matrix4-Pool pro Bone anlegen statt Map.clear() pro Frame.
+const _skinMatCache = new Map();
+
+function _getSkinMat(bone, bindInv) {
+  let m = _skinMatCache.get(bone);
+  if (m) return m;
+  const boneObj = nodeObjects[bone];
+  if (!boneObj || !bindInv[bone]) return null;
+  m = new THREE.Matrix4();
+  _sk.boneMat.multiplyMatrices(_sk.mgInv, boneObj.matrixWorld);
+  m.multiplyMatrices(_sk.boneMat, bindInv[bone]);
+  _skinMatCache.set(bone, m);
+  return m;
+}
 
 function applySkinning() {
   if (!currentModel || !window._nwnBindInvMatrices || !window._nwnModelGroup) return;
@@ -223,6 +241,10 @@ function applySkinning() {
   // Compute mg_inv once per frame: transforms bone.matrixWorld into NWN space
   mg.updateMatrixWorld(true);
   _sk.mgInv.copy(mg.matrixWorld).invert();
+
+  // Eine Skin-Matrix pro Bone für diesen Frame — wird beim ersten
+  // Vertex, der den Bone nutzt, berechnet und danach wiederverwendet.
+  _skinMatCache.clear();
 
   for (const node of currentModel.nodes) {
     if (node.type !== 'skin') continue;
@@ -243,14 +265,10 @@ function applySkinning() {
 
       let totalW = 0;
       for (const { bone, weight } of pairs) {
-        const boneObj = nodeObjects[bone];
-        if (!boneObj || !bindInv[bone]) continue;
+        const skinMat = _getSkinMat(bone, bindInv);
+        if (!skinMat) continue;
 
-        // Current bone in NWN space
-        _sk.boneMat.multiplyMatrices(_sk.mgInv, boneObj.matrixWorld);
-        _sk.skinMat.multiplyMatrices(_sk.boneMat, bindInv[bone]);
-
-        _sk.vTmp.copy(_sk.vBind).applyMatrix4(_sk.skinMat);
+        _sk.vTmp.copy(_sk.vBind).applyMatrix4(skinMat);
         _sk.vFinal.addScaledVector(_sk.vTmp, weight);
         totalW += weight;
       }

--- a/js/loader.js
+++ b/js/loader.js
@@ -4,6 +4,39 @@
 
 //  Multi-File Loader  (MDL + textures simultaneously)
 // ─────────────────────────────────────────────
+
+  const NWN_BONE_MAP = {
+      'chest':  'torso_g',
+      'pelvis': 'pelvis_g',
+      'belt':   'belt_g1',
+      'neck':   'neck_g',
+      'head':   'head_g',
+      'shol':   'lbicep_g',    // shoulder plate: left shoulder joint
+      'shor':   'rbicep_g',    //                 right shoulder joint
+      'bicepl': 'lbicep_g',    // upper arm left
+      'bicepr': 'rbicep_g',    // upper arm right
+      'forel':  'lforearm_g',  // forearm left
+      'forer':  'rforearm_g',  // forearm right
+      'handl':  'lhand_g',     // hand left
+      'handr':  'rhand_g',     // hand right
+      'legl':   'lthigh_g',    // thigh left
+      'legr':   'rthigh_g',    // thigh right
+      'shinl':  'lshin_g',     // shin left
+      'shinr':  'rshin_g',     // shin right
+      'footl':  'lfoot_g',     // foot left
+      'footr':  'rfoot_g',     // foot right*/
+  };
+  
+  const NWN_ARM_CHAINS = [
+    ['shol', 'bicepl', 'forel', 'handl'],
+    ['shor', 'bicepr', 'forer', 'handr'],
+  ];
+
+  const NWN_SPINE_GROUPS = [
+    ['footl', 'footr'], ['shinl', 'shinr'], ['legl', 'legr'],
+    ['pelvis'], ['belt'], ['chest'], ['neck'], ['head'],
+  ];
+
 function loadFiles(fileList) {
   if (!fileList || fileList.length === 0) return;
 
@@ -489,7 +522,7 @@ function mergeAnimationsFromSupermodel(mainModel, superModel) {
 
   // FIX: NWN node names are inconsistently cased across different files
   // (e.g., "Lbicep_g" vs. "lbicep_g") — the same issue already handled
-  // during the BONE_MAP lookup in character part assembly.
+  // during the NWN_BONE_MAP lookup in character part assembly.
   // Lowercase → original-casing map, ensuring animation keys match
   // the mainModel node names (and thus nodeObjects) exactly.
   const mainNodeNamesLC = new Map();
@@ -709,7 +742,7 @@ function positionCharacterParts(charParts, skeletonModel) {
 
     // NWN part abbreviation → attachment node name in skeleton
     // Source: pmh0.mdl analysis (applies to all pm[mf][0-9].mdl base skeletons)
-    const BONE_MAP = {
+/*  const BONE_MAP = {
       'chest':  'torso_g',
       'pelvis': 'pelvis_g',
       'belt':   'belt_g1',
@@ -729,7 +762,7 @@ function positionCharacterParts(charParts, skeletonModel) {
       'shinr':  'rshin_g',     // shin right
       'footl':  'lfoot_g',     // foot left
       'footr':  'rfoot_g',     // foot right
-    };
+    };*/
 
     // World positions of all skeleton nodes via hierarchy traversal
     const nodeMap = {};
@@ -760,7 +793,7 @@ function positionCharacterParts(charParts, skeletonModel) {
 
     // Place each part at its attachment node
     for (const part of charParts) {
-      const bone = BONE_MAP[partKey(part.name.toLowerCase())];
+      const bone = NWN_BONE_MAP[partKey(part.name.toLowerCase())];
       if (!bone) continue;
       const wp = worldPos[bone];
       if (!wp) continue;
@@ -787,14 +820,9 @@ function positionCharacterParts(charParts, skeletonModel) {
   }
 
   // Phase 2a: spine + legs along Z axis (NWN: Z = up)
-  const SPINE_GROUPS = [
-    ['footl', 'footr'], ['shinl', 'shinr'], ['legl', 'legr'],
-    ['pelvis'], ['belt'], ['chest'], ['neck'], ['head'],
-  ];
-
   let floorZ = 0, chestTopZ = 0;
 
-  for (const keys of SPINE_GROUPS) {
+  for (const keys of NWN_SPINE_GROUPS) {
     const parts = keys.map(findPart).filter(Boolean);
     if (!parts.length) continue;
     let gMinZ = Infinity, gMaxZ = -Infinity;
@@ -816,11 +844,7 @@ function positionCharacterParts(charParts, skeletonModel) {
   if (chestTopZ === 0) chestTopZ = floorZ;
 
   // Phase 2b: arms hang downward from the chest top edge
-  const ARM_CHAINS = [
-    ['shol', 'bicepl', 'forel', 'handl'],
-    ['shor', 'bicepr', 'forer', 'handr'],
-  ];
-  for (const chain of ARM_CHAINS) {
+  for (const chain of NWN_ARM_CHAINS) {
     let armTopZ = chestTopZ;
     for (const key of chain) {
       const part = findPart(key);
@@ -948,7 +972,7 @@ function loadAllMDLFiles(mdlFiles) {
           // in space by Three.js (including parent rotations).
           // → boneObj.add(partRoot) + position (0,0,0): part lands exactly at bone origin.
           if (skeletonModel) {
-            const BONE_MAP = {
+/*          const BONE_MAP = {
               'chest':  'torso_g',    'pelvis': 'pelvis_g',   'belt':   'belt_g1',
               'neck':   'neck_g',     'head':   'head_g',
               'shol':   'lbicep_g',   'shor':   'rbicep_g',
@@ -958,11 +982,11 @@ function loadAllMDLFiles(mdlFiles) {
               'legl':   'lthigh_g',   'legr':   'rthigh_g',
               'shinl':  'lshin_g',    'shinr':  'rshin_g',
               'footl':  'lfoot_g',    'footr':  'rfoot_g',
-            };
+            };*/
 
             // Case-insensitive bone lookup: skeletons of different models
             // use different capitalisations (e.g. Lbicep_g vs lbicep_g).
-            // BONE_MAP values are always lowercase → build LC map once.
+            // NWN_BONE_MAP values are always lowercase → build LC map once.
             const nodeObjLC = {};
             for (const [k, v] of Object.entries(nodeObjects)) {
               if (k) nodeObjLC[k.toLowerCase()] = v;
@@ -972,7 +996,7 @@ function loadAllMDLFiles(mdlFiles) {
             for (const part of charParts) {
               if (part === base) continue;
               const m = part.name.match(/^p[mf][a-z]\d_([a-z]+)\d+$/i);
-              const boneName = BONE_MAP[m ? m[1].toLowerCase() : ''];
+              const boneName = NWN_BONE_MAP[m ? m[1].toLowerCase() : ''];
               if (!boneName) continue;
               const partRoot = nodeObjects[part.name];
               const boneObj  = nodeObjLC[boneName];
@@ -986,7 +1010,7 @@ function loadAllMDLFiles(mdlFiles) {
             // The base root itself cannot be moved (all bones hang from it).
             // Its geometry meshes (non-skeleton nodes) are attached directly
             // under their bone attachment node, like all other parts.
-            const pelvisGObj   = nodeObjLC[BONE_MAP['pelvis']];
+            const pelvisGObj   = nodeObjLC[NWN_BONE_MAP['pelvis']];
             const baseRootObj  = nodeObjects[base.name];
             if (pelvisGObj && baseRootObj) {
               const skelNodeNames = new Set(

--- a/js/loader.js
+++ b/js/loader.js
@@ -63,6 +63,7 @@ function loadFiles(fileList) {
     if (!isSupermodelLoad) {
       clearSession();
       clearLog();
+    //console.clear();  // do I want a complete cleanup, even if errors occurred?
       // Model name hint for collapsed sidebar
       const baseName = mdlFiles[0].name.replace(/\.[^.]+$/, '');
       const hint = document.getElementById('model-name-hint');

--- a/js/scene.js
+++ b/js/scene.js
@@ -88,7 +88,28 @@ const orbit = {
   dragging: false, panning: false,
   lastX: 0, lastY: 0,
   panStart: null,
+  // FIX: Screen-space pan offset, decoupled from orbit.target.
+  // Panning used to permanently shift orbit.target (the rotation pivot) in
+  // world space — once Auto-Rotate was enabled afterwards, the camera then
+  // orbited around that shifted point instead of the model's real center,
+  // causing the model to swing out of view and back during rotation.
+  // panX/panY instead store a screen-space offset (right/up in camera basis,
+  // world units) that is re-applied every frame in updateCamera() using the
+  // *current* view direction. orbit.target itself always stays the model's
+  // true center (set on load, see scene_build.js), so rotation is always
+  // clean — and the user's deliberate "push it aside" pan is preserved as a
+  // constant on-screen position throughout the rotation.
+  panX: 0, panY: 0,
 };
+
+// Scratch objects for updateCamera() — avoids per-frame allocation during
+// Auto-Rotate (called every animation frame in that mode).
+const _camBasePos  = new THREE.Vector3();
+const _camDir      = new THREE.Vector3();
+const _camRight    = new THREE.Vector3();
+const _camUp       = new THREE.Vector3();
+const _camOffset   = new THREE.Vector3();
+const _camLookAt   = new THREE.Vector3();
 
 function updateCamera() {
   orbit.phi = Math.max(0.05, Math.min(Math.PI - 0.05, orbit.phi));
@@ -96,12 +117,35 @@ function updateCamera() {
   const x = orbit.radius * Math.sin(orbit.phi) * Math.sin(orbit.theta);
   const y = orbit.radius * Math.cos(orbit.phi);
   const z = orbit.radius * Math.sin(orbit.phi) * Math.cos(orbit.theta);
-  camera.position.set(
+
+  // Base camera position, orbiting the true rotation center (orbit.target).
+  _camBasePos.set(
     orbit.target.x + x,
     orbit.target.y + y,
     orbit.target.z + z
   );
-  camera.lookAt(orbit.target);
+
+  if (orbit.panX === 0 && orbit.panY === 0) {
+    camera.position.copy(_camBasePos);
+    camera.lookAt(orbit.target);
+    return;
+  }
+
+  // FIX: Re-derive right/up from the current view direction every call
+  // (not from camera.getWorldDirection(), which lags one frame behind)
+  // so the pan offset always reads as the same screen-space position,
+  // regardless of how theta/phi have rotated since the pan was applied.
+  _camDir.subVectors(orbit.target, _camBasePos).normalize();
+  _camRight.crossVectors(_camDir, camera.up).normalize();
+  _camUp.crossVectors(_camRight, _camDir).normalize();
+
+  _camOffset.set(0, 0, 0)
+    .addScaledVector(_camRight, orbit.panX)
+    .addScaledVector(_camUp, orbit.panY);
+
+  camera.position.copy(_camBasePos).add(_camOffset);
+  _camLookAt.copy(orbit.target).add(_camOffset);
+  camera.lookAt(_camLookAt);
 }
 
 canvas.addEventListener('mousedown', e => {
@@ -121,14 +165,12 @@ window.addEventListener('mousemove', e => {
     updateCamera();
   }
   if (orbit.panning) {
-    const right = new THREE.Vector3();
-    const up = new THREE.Vector3();
-    camera.getWorldDirection(new THREE.Vector3());
-    right.crossVectors(camera.getWorldDirection(new THREE.Vector3()), camera.up).normalize();
-    up.copy(camera.up);
+    // FIX: accumulate into the screen-space pan offset instead of moving
+    // orbit.target — keeps the rotation pivot at the model's true center.
+    // Sign convention matches the previous target-shift behaviour exactly.
     const speed = orbit.radius * 0.001;
-    orbit.target.addScaledVector(right, -dx * speed);
-    orbit.target.addScaledVector(up, dy * speed);
+    orbit.panX += -dx * speed;
+    orbit.panY +=  dy * speed;
     updateCamera();
   }
 });
@@ -204,13 +246,13 @@ canvas.addEventListener('touchmove', e => {
     const midX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
     const midY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
     if (_pinchMidX !== null) {
+      // FIX: same screen-space offset accumulation as the mouse pan above,
+      // instead of permanently shifting orbit.target.
       const pdx   = midX - _pinchMidX;
       const pdy   = midY - _pinchMidY;
-      const right = new THREE.Vector3();
-      right.crossVectors(camera.getWorldDirection(new THREE.Vector3()), camera.up).normalize();
       const speed = orbit.radius * 0.001;
-      orbit.target.addScaledVector(right, -pdx * speed);
-      orbit.target.addScaledVector(camera.up,  pdy * speed);
+      orbit.panX += -pdx * speed;
+      orbit.panY +=  pdy * speed;
       updateCamera();
     }
     _pinchMidX = midX;

--- a/js/scene_build.js
+++ b/js/scene_build.js
@@ -638,8 +638,6 @@ function buildScene(model) {
         obj.add(backMesh);
       }
 
-      totalVerts += node.verts.length;   // ← already present 
-      
       totalVerts += node.verts.length;
       totalFaces += node.faces.length;
     } else if (node.type === 'aabb' && node.faces.length > 0 && node.verts.length > 0) {

--- a/js/scene_build.js
+++ b/js/scene_build.js
@@ -93,34 +93,47 @@ function computeSGNormals(node) {
         }
       }
     }
+    
+    // Map → typed arrays. Cluster keys fall within a known, small
+    // value range (n is typically 2–6)—an array index is cheaper
+    // here than a hash lookup. Group IDs: cluster roots (sg≠0) lie
+    // in [0, n) via _find(i); isolated sg=0 faces are assigned
+    // n+i e [n, 2n) so that the two ranges never collide.
+    const groupCount = n * 2;
+    const clNX = new Float64Array(groupCount);
+    const clNY = new Float64Array(groupCount);
+    const clNZ = new Float64Array(groupCount);
+    const groupOf = new Int32Array(n);
 
-    // Accumulate cluster normals
-    const clNX = new Map(), clNY = new Map(), clNZ = new Map();
     for (let i = 0; i < n; i++) {
-      // sg=0: each face gets a unique key → no merge
-      const key = (faces[fList[i]].sg === 0) ? ~i : _find(i);
-      clNX.set(key, (clNX.get(key) || 0) + faceNX[fList[i]]);
-      clNY.set(key, (clNY.get(key) || 0) + faceNY[fList[i]]);
-      clNZ.set(key, (clNZ.get(key) || 0) + faceNZ[fList[i]]);
+      const key = (faces[fList[i]].sg === 0) ? (n + i) : _find(i);
+      groupOf[i] = key;
+      clNX[key] += faceNX[fList[i]];
+      clNY[key] += faceNY[fList[i]];
+      clNZ[key] += faceNZ[fList[i]];
     }
 
-    // Normalize
-    const nrmX = new Map(), nrmY = new Map(), nrmZ = new Map();
-    for (const [key, nx] of clNX) {
-      const ny = clNY.get(key), nz = clNZ.get(key);
-      const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
-      nrmX.set(key, nx / len); nrmY.set(key, ny / len); nrmZ.set(key, nz / len);
+    // Normalize every used group slot in place (n is small, so
+    // negligibly cheap, even if a few slots remain unused)
+    for (let g = 0; g < groupCount; g++) {
+      const nx = clNX[g], ny = clNY[g], nz = clNZ[g];
+    //const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;  // until changes in v184
+      const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+      if (len > 1e-8) {
+        clNX[g] = nx / len; clNY[g] = ny / len; clNZ[g] = nz / len;
+      }
     }
 
-    // Write to exploded buffer
+    // Write to exploded buffer — groupOf[i] wiederverwendet den bereits
+    // berechneten Schlüssel statt _find(i) ein zweites Mal aufzurufen.
     for (let i = 0; i < n; i++) {
       const fi  = fList[i];
-      const key = (faces[fi].sg === 0) ? ~i : _find(i);
+      const key = groupOf[i];
       for (let k = 0; k < 3; k++) {
         if (faces[fi].v[k] === vi) {
-          out[fi * 9 + k * 3 + 0] = nrmX.get(key);
-          out[fi * 9 + k * 3 + 1] = nrmY.get(key);
-          out[fi * 9 + k * 3 + 2] = nrmZ.get(key);
+          out[fi * 9 + k * 3 + 0] = clNX[key];
+          out[fi * 9 + k * 3 + 1] = clNY[key];
+          out[fi * 9 + k * 3 + 2] = clNZ[key];
           break;
         }
       }

--- a/js/setbrowser.js
+++ b/js/setbrowser.js
@@ -753,6 +753,7 @@ const SetBrowser = (() => {
   }
 
   function _renderGrid(container, tiles) {
+    const frag = document.createDocumentFragment();   // ←
     for (const tile of tiles) {
       const el = document.createElement('div');
       el.className       = 'sb-tile';
@@ -763,11 +764,13 @@ const SetBrowser = (() => {
       el.innerHTML =
         `<span class="sb-tile-nr">#${String(tile.nr).padStart(3, '0')}</span>` +
         `<span class="sb-tile-model">${tile.model || '—'}</span>`;
-      container.appendChild(el);
+      frag.appendChild(el);
     }
+    container.appendChild(frag);
   }
 
   function _renderList(container, tiles) {
+    const frag = document.createDocumentFragment();   // ←
     for (const tile of tiles) {
       const el = document.createElement('div');
       el.className      = 'sb-tile sb-tile-row';
@@ -784,10 +787,10 @@ const SetBrowser = (() => {
         `<span class="sb-col-nr">#${String(tile.nr).padStart(3, '0')}</span>` +
         `<span class="sb-col-model">${tile.model || '—'}</span>` +
         `<span class="sb-col-terrain">${terrainStr}</span>`;
-      container.appendChild(el);
+      frag.appendChild(el);
     }
+    container.appendChild(frag);
   }
-
 
   // ════════════════════════════════════════════════════════════
   //  ZOOM  (font size in tile container)

--- a/js/ui.js
+++ b/js/ui.js
@@ -23,6 +23,12 @@ function buildNodeList(model) {
     // Initialize type button state (all visible → all active)
     nodeVisUpdateTypeButtons();
   }
+  
+  // Items are collected in a fragment instead of being appended to the
+  // live DOM individually — for large tilesets (set browser groups), this
+  // prevents hundreds of individual reflows.
+  const frag = document.createDocumentFragment();
+  
   for (const node of model.nodes) {
     const item = document.createElement('div');
     item.className = 'node-item';
@@ -69,8 +75,10 @@ function buildNodeList(model) {
     }
 
     item.onclick = () => selectNode(node.name);
-    list.appendChild(item);
+    frag.appendChild(item);
   }
+  
+  list.appendChild(frag);
 }
 
 function toggleNodeVisibility(name, item, btn, visibleIcon) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -460,6 +460,11 @@ function resetCamera() {
   orbit.radius = orbit.initRadius;
   orbit.theta  = orbit.initTheta;
   orbit.phi    = orbit.initPhi;
+  // FIX: also clear the screen-space pan offset (see scene.js) — otherwise
+  // "↺ Cam" would re-center theta/phi/radius but leave the model visually
+  // shifted from a previous deliberate pan.
+  orbit.panX = 0;
+  orbit.panY = 0;
   updateCamera();
 }
 


### PR DESCRIPTION
There were several areas where the code could be simplified. This should result in slightly faster loading times for larger models and improved performance when using the set browser with groups. Additionally, a few constants that had been declared multiple times were converted into global constants. Finally, the pivot point for the rotate function was adjusted so that, when moving the model, it rotates around its own center rather than the center of the 3D viewport (which closes #174).