### PR TITLE
v188 added fallback solutions for vendored files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@
 #
 #  Workflow:
 #    1. update-wasm   → Ensures cleanmodels.wasm is up to date
-#    2. release        → Builds standalone HTML + source ZIP and publishes
+#    2. release       → Builds standalone HTML + source ZIP and publishes
 #
 #  Triggers:
 #    - Push of a version tag:  git tag v1.2.3 && git push --tags
@@ -79,6 +79,7 @@ jobs:
             css/ \
             js/ \
             lang/ \
+            vendor/ \
             wasm/ \
             scripts/ \
             themes/ \
@@ -158,8 +159,8 @@ jobs:
             dist/nwn-mdl-webviewer-src.zip
 
   # ── Job 3: Deploy to GitHub Pages ──────────────────────────────────────────
-  # Ruft pages.yml als reusable workflow auf und übergibt die bekannte Version.
-  # So landet immer die korrekte Versionsnummer auch auf GitHub Pages.
+  # Calls pages.yml as a reusable workflow and passes the known version.
+  # This ensures the correct version number always ends up on GitHub Pages.
   deploy-pages:
     needs: release
     uses: ./.github/workflows/pages.yml

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NWN MDL Viewer</title>
-  <link rel="stylesheet" href="vendor/fonts/fonts.css">
+  <link rel="stylesheet" href="vendor/fonts/fonts.css"
+      onerror="this.onerror=null;this.href='https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600&family=Share+Tech+Mono&display=swap';">
   <link rel="stylesheet" href="css/viewer.css">
 </head>
 <body>
@@ -264,8 +265,15 @@
   </div>
 </div>
 
-<!-- Three.js r152 (vendored locally - see vendor/README.md for provenance / hash verification) -->
+<!-- Three.js r152 (vendored locally - see vendor/README.md for provenance / hash verification).
+     Falls back to the CDN build if vendor/ was not shipped alongside this HTML file
+     (e.g. the standalone single-file release opened on its own). -->
 <script src="vendor/three/three.min.js"></script>
+<script>
+  if (typeof THREE === 'undefined') {
+    document.write('<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/0.152.0/three.min.js" integrity="sha512-Xr/WOAkCSWjhjwU5imbX1t2vZA4mDHqQJkuXOgzWH28GNXC9BfzuO54z3Byhb1xYGedSGlDMqFaoAI6DtOtC2g==" crossorigin="anonymous" referrerpolicy="no-referrer"><\/script>');
+  }
+</script>
   
 <!-- NWN MDL Viewer — Module -->
 <script src="js/i18n.js"></script>        <!-- Translation --!>


### PR DESCRIPTION
The build.py file and the HTML file did not contain the required files or a corresponding fallback. Closes #180 .