### PR TITLE
V192 add pos highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ No installation, no server — just open `index.html` locally or use it directly
 - **Collision-safe visibility** — In group-loaded tileset scenes, multiple tiles may share identical node names (e.g. `walkmesh` on AABB nodes, or generic mesh names like `ground01`). Each scene graph entry correctly controls its own specific Three.js object regardless of name collisions — visibility toggles and type-filter buttons all resolve to the right tile.
 - **Node Inspector** — Draggable floating panel with zoom controls (−/○/＋); shows: type, parent, vertices, faces, bitmap, position, diffuse, alpha, plus type-specific sections for emitter nodes (all parameters), light nodes (color, radius, multiplier, shadow, etc.), and MTR nodes (slot status, renderhint, tangent status, shader parameters)
 - **Skeleton Helper** — Three.js SkeletonHelper overlay for skinned models; toggled via the Skeleton button
+- **Node selection** — Click a node in the Scene Graph sidebar, or **Ctrl+Click** (Cmd+Click on macOS) directly on a mesh in the 3D viewport, to select it and open the Node Inspector panel
+- **Selection highlight** — The selected mesh is outlined with a static white highlight (visible on trimesh, skin, danglymesh, and animmesh nodes); automatically follows CPU-skinning and danglymesh deformation, and clears when a different node is selected or the panel is closed
+- **Deselect** — Ctrl+Click (Cmd+Click on macOS) on empty space in the viewport closes the Node Inspector and clears the selection highlight
 
 ### Camera & Display Controls
 | Control | Description |

--- a/index.html
+++ b/index.html
@@ -273,7 +273,7 @@
 <script src="vendor/three/three.min.js"></script>
 <script>
   if (typeof THREE === 'undefined') {
-    document.write('<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/0.158.0/three.min.js" integrity="sha512-/WaZCC76Yn6MLEoK6b9np9yiLBet/RngBS33X1P0SHuag6j2E0e5rT7jbA2CvXCydN6+FkDYNx8FBM+vkzsthw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>');
+    document.write('<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/0.158.0/three.min.js" integrity="sha512-/WaZCC76Yn6MLEoK6b9np9yiLBet/RngBS33X1P0SHuag6j2E0e5rT7jbA2CvXCydN6+FkDYNx8FBM+vkzsthw==" crossorigin="anonymous" referrerpolicy="no-referrer"><\/script>');
   }
 </script>
   

--- a/js/animation.js
+++ b/js/animation.js
@@ -121,6 +121,19 @@ function applyAnimFrame(anim, time) {
       }
     }
 
+    // Interpolate selfillumcolor (selfillumcolorkey / selfillumcolorbezierkey —
+    // animated emissive color for EFFECT-class nodes)
+    const sicKeys = data.emitterKeys && data.emitterKeys.selfillumcolor;
+    if (sicKeys && sicKeys.length > 0) {
+      const v = lerpEmitterKey(sicKeys, time);
+      if (v && v.length >= 3) {
+        const mats = obj.material ? (Array.isArray(obj.material) ? obj.material : [obj.material]) : [];
+        for (const mat of mats) {
+          if (mat.emissiveMap) mat.emissive.setRGB(v[0], v[1], v[2]);
+        }
+      }
+    }
+
     // Animate light properties (colorkey, radiuskey, multiplierkey)
     const mdlLight = obj.userData && obj.userData.mdlLight;
     if (mdlLight && data.emitterKeys) {

--- a/js/emitter.js
+++ b/js/emitter.js
@@ -111,8 +111,7 @@ class NWNParticle {
    * @param {THREE.Vector3} localX    – Local +X axis in world space (for xsize spread)
    * @param {THREE.Vector3} localY    – Local +Y axis in world space (for ysize spread)
    */
-   
-spawn(worldPos, node, emitDir, localX, localY, p2pTarget = null) {
+  spawn(worldPos, node, emitDir, localX, localY, p2pTarget = null) {
     this.node        = node;
     this.age         = 0;
     this.alive       = true;
@@ -588,6 +587,58 @@ class NWNEmitter {
   }
 }
 
+// ─────────────────────────────────────────────
+//  NWNLightningBolt  —  static beam between emitter and reference node
+//  (minimal lightning representation; see update=Lightning in initAllEmitters)
+// ─────────────────────────────────────────────
+class NWNLightningBolt {
+  constructor(node) {
+    this.node = node;
+    this.obj  = null;
+    this._build();
+  }
+
+  _build() {
+    const emitterObj = nodeObjects[this.node.name];
+    const targetObj  = nodeObjects[this.node._p2pTargetName];
+    if (!emitterObj || !targetObj) return;
+
+    const from = new THREE.Vector3();
+    const to   = new THREE.Vector3();
+    emitterObj.getWorldPosition(from);
+    targetObj.getWorldPosition(to);
+
+    // Use the same color as the emitter markers in scene_build.js (colorStart);
+    // switch to an electric blue if the value is too dark.
+    const cs  = this.node.colorStart || [0.6, 0.8, 1.0];
+    const lum = cs[0] * 0.299 + cs[1] * 0.587 + cs[2] * 0.114;
+    const color = lum < 0.05 ? new THREE.Color(0x88ccff) : new THREE.Color(cs[0], cs[1], cs[2]);
+
+    const geo = new THREE.BufferGeometry().setFromPoints([from, to]);
+    const mat = new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.85 });
+    this.obj = new THREE.Line(geo, mat);
+    this.obj.userData.isLightningBolt = true;
+    scene.add(this.obj);
+  }
+
+  /** Reflects the visibility of the emitter node (scene graph toggle). */
+  update(dt) {
+    const emitterObj = nodeObjects[this.node.name];
+    if (this.obj && emitterObj) this.obj.visible = emitterObj.visible;
+  }
+
+  /** No texture state — no-op for the shared refreshEmitterTextures() loop. */
+  refreshTexture() {}
+
+  dispose() {
+    if (this.obj) {
+      scene.remove(this.obj);
+      this.obj.geometry.dispose();
+      this.obj.material.dispose();
+      this.obj = null;
+    }
+  }
+}
 
 // ─────────────────────────────────────────────
 //  Global API  —  used by other modules
@@ -603,7 +654,32 @@ function initAllEmitters(model) {
   if (!model) return;
   for (const node of model.nodes) {
     if (node.type !== 'emitter') continue;
-    if (!node.emitterTexture)    continue;
+
+    // ── Resolve P2P target point ────────────────────────────────────────────
+    // A reference node as a child node is mandatory for p2p=1 AND for
+    // update=Lightning (according to NWN documentation, Lightning is a specialized
+    // p2p emitter) — therefore, resolve it here for both cases.
+    const isLightning = (node.update || '').toLowerCase() === 'lightning';
+    node._p2pTargetName = (node.p2p || isLightning)
+      ? (model.nodes.find(n => n.parent === node.name && n.type === 'reference')?.name || null)
+      : null;
+
+    // ── Lightning: static beam instead of particle sprites ────────────────
+    // ponytail: no fractal/flickering (subdivision/lightningRadius/lightningScale
+    // unused), fixed static beam upon model load. Upgrade path if
+    // needed: periodic midpoint displacement recalculation in update().
+    if (isLightning) {
+      if (!node._p2pTargetName) continue;   // keine Reference-Node → nichts zu zeichnen
+      try {
+        emitterInstances[node.name] = new NWNLightningBolt(node);
+        logInfo(fmt('log_em_init', { name: node.name }) + L('log_em_lightning_static'));
+      } catch (err) {
+        logWarn(fmt('log_em_error', { name: node.name, msg: err.message }));
+      }
+      continue;
+    }
+
+    if (!node.emitterTexture) continue;
 
     // ── Search for birthratekey in animation data ────────────────────────
     // NWN effect models often have birthrate=0 in the geometry block and control

--- a/js/emitter.js
+++ b/js/emitter.js
@@ -111,7 +111,8 @@ class NWNParticle {
    * @param {THREE.Vector3} localX    – Local +X axis in world space (for xsize spread)
    * @param {THREE.Vector3} localY    – Local +Y axis in world space (for ysize spread)
    */
-  spawn(worldPos, node, emitDir, localX, localY) {
+   
+spawn(worldPos, node, emitDir, localX, localY, p2pTarget = null) {
     this.node        = node;
     this.age         = 0;
     this.alive       = true;

--- a/js/emitter.js
+++ b/js/emitter.js
@@ -30,12 +30,13 @@ const emitterInstances = {};
 // ─────────────────────────────────────────────
 class NWNParticle {
   /**
-   * @param {THREE.Texture} baseTex    – Shared canvas texture (textureCache entry)
-   * @param {number}        xgrid      – Sprite-sheet columns
-   * @param {number}        ygrid      – Sprite-sheet rows
-   * @param {string}        renderMode – NWN render mode of the emitter (e.g. 'Billboard_to_World_Z')
+   * @param {THREE.Texture} baseTex      – Shared canvas texture (textureCache entry)
+   * @param {number}        xgrid        – Sprite-sheet columns
+   * @param {number}        ygrid        – Sprite-sheet rows
+   * @param {string}        renderMode   – NWN render mode of the emitter (e.g. 'Billboard_to_World_Z')
+   * @param {boolean}       isLinkedP2P  – true for p2p=1 + render=Linked (beam/bolt quad)
    */
-  constructor(baseTex, xgrid, ygrid, renderMode) {
+  constructor(baseTex, xgrid, ygrid, renderMode, isLinkedP2P) {
     this.xgrid = xgrid;
     this.ygrid = ygrid;
 
@@ -43,6 +44,11 @@ class NWNParticle {
     // not camera-facing. For all other modes: standard THREE.Sprite.
     this.isFlatBillboard =
       (renderMode || '').toLowerCase() === 'billboard_to_world_z';
+
+    // p2p=1 + render=Linked (e.g. lightning bolts): NWN renders these as a
+    // single quad stretched between the emitter and its P2P target, not as
+    // independent moving billboards. See _updateBeamTransform().
+    this.isLinkedP2P = !!isLinkedP2P;
 
     // Clone texture: shares canvas pixel data but has its own offset/repeat vectors.
     // THREE.Texture.clone() → new THREE.CanvasTexture with the same .image (canvas).
@@ -55,7 +61,27 @@ class NWNParticle {
     // (visually top) lands at WebGL v=0 (sprite bottom) — without correction
     // every frame would be upside down. repeat.y < 0 inverts the v direction.
 
-    if (this.isFlatBillboard) {
+    if (this.isLinkedP2P) {
+      // ── Beam quad: stretched between emitter origin and P2P target ────
+      // Rebuilt every frame in _updateBeamTransform() (camera-billboarded
+      // around its own long axis — the classic "laser beam" technique).
+      // ponytail: single flat quad, not a fractal/jittered bolt shape — the
+      // short lifeExp + fast birthrate + random sprite-sheet frame already
+      // reproduce the flickering jagged look closely enough. Upgrade path:
+      // multi-segment jitter along the beam if a truer zig-zag is needed.
+      this.mat = new THREE.MeshBasicMaterial({
+        map:         this.tex,
+        blending:    THREE.AdditiveBlending,
+        depthWrite:  false,
+        transparent: true,
+        side:        THREE.DoubleSide,
+        fog:         false,
+      });
+      const geo = new THREE.PlaneGeometry(1, 1);
+      this.obj = new THREE.Mesh(geo, this.mat);
+      this.obj.matrixAutoUpdate = false;   // matrix is fully hand-built per frame
+      this.p2pOrigin = new THREE.Vector3();
+    } else if (this.isFlatBillboard) {
       // ── Billboard_to_World_Z: flat quad horizontal in the XZ plane ──
       // PlaneGeometry is by default in the XY plane (normal = +Z).
       // Rotation −90° around X rotates it into the XZ plane (normal = +Y = upward).
@@ -118,6 +144,17 @@ class NWNParticle {
     this.rotation    = 0;
     this.obj.visible = true;
     this.p2pTarget   = p2pTarget;
+
+    if (this.isLinkedP2P) {
+      // Beam particles ignore spawn-area jitter and velocity entirely —
+      // the quad's transform is fully rebuilt from origin → target every
+      // frame in _updateBeamTransform(). Without a target, there's nothing
+      // to draw (matches the ordinary emitter's silent no-op elsewhere).
+      this.p2pOrigin.copy(worldPos);
+      const totalFrames = node.frameEnd - node.frameStart + 1;
+      this.startFrame   = node.frameStart + Math.floor(Math.random() * totalFrames);
+      return;
+    }
 
     // ── Emitter direction ────────────────────────────────────────────
     const dir = (emitDir && emitDir.lengthSq() > 0.01)
@@ -193,11 +230,20 @@ class NWNParticle {
     const t = this.age / node.lifeExp;   // normalised lifetime 0..1
 
     // ── Position (Euler integration) ──────────────────────────────
-    this.obj.position.x += this.vx * dt;
-    this.obj.position.y += this.vy * dt;
-    this.obj.position.z += this.vz * dt;
+    // Beam mode (isLinkedP2P) skips velocity/gravity entirely — grav is
+    // often 0 on these emitters (the bolt spans the gap via the beam's
+    // geometry in _updateBeamTransform() below, not by a particle
+    // traveling there over its short lifeExp).
+    if (!this.isLinkedP2P) {
+      this.obj.position.x += this.vx * dt;
+      this.obj.position.y += this.vy * dt;
+      this.obj.position.z += this.vz * dt;
+    }
 
-    if (this.p2pTarget) {
+    if (this.isLinkedP2P) {
+      // Beam mode has no velocity to advance — skip gravity/drag/rotation
+      // entirely; only the size/alpha/color/frame curves below still apply.
+    } else if (this.p2pTarget) {
       // ── Point-to-Point (Gravity) physics ──────────────────────────────
       // p2p_sel=0: Instead of normal gravity, the particle is pulled toward
       // the target point (Reference Node). According to NWN documentation,
@@ -282,7 +328,11 @@ class NWNParticle {
         ? sS + (sM - sS) * (t * 2)
         : sM + (sE - sM) * ((t - 0.5) * 2);
     }
-    this.obj.scale.setScalar(Math.max(size, 0.001));
+    if (this.isLinkedP2P) {
+      this._updateBeamTransform(Math.max(size, 0.001));
+    } else {
+      this.obj.scale.setScalar(Math.max(size, 0.001));
+    }
 
     // ── Alpha: alphaStart → alphaMid → alphaEnd ───────────────────
     const aS = node.alphaStart, aM = node.alphaMid, aE = node.alphaEnd;
@@ -324,13 +374,64 @@ class NWNParticle {
     return true;
   }
 
+  /**
+   * Rebuilds this particle's quad so it spans from the emitter origin to the
+   * P2P target (the reference node), billboarded around its own long axis —
+   * i.e. it always faces the camera as closely as possible while its length
+   * stays pinned to the two 3D endpoints ("laser beam" technique). Called
+   * every frame instead of position/velocity integration.
+   * @param {number} width – current beam width from the size curve
+   */
+  _updateBeamTransform(width) {
+    if (!this.p2pTarget) { this.obj.visible = false; return; }
+
+    _beamDir.subVectors(this.p2pTarget, this.p2pOrigin);
+    const length = _beamDir.length();
+    if (length < 1e-4) { this.obj.visible = false; return; }
+    _beamDir.multiplyScalar(1 / length);
+
+    // Camera-facing normal, perpendicular to the beam.
+    _beamToCam.subVectors(camera.position, this.p2pOrigin).normalize();
+    _beamRight.crossVectors(_beamDir, _beamToCam);
+    if (_beamRight.lengthSq() < 1e-6) {
+      // Camera nearly along the beam axis — fall back to world-up so the
+      // basis never degenerates (would otherwise collapse the quad to zero width).
+      _beamRight.crossVectors(_beamDir, _beamUp);
+    }
+    _beamRight.normalize();
+    _beamNormal.crossVectors(_beamRight, _beamDir).normalize();
+
+    // Local X = width (right), local Y = length (beam direction), local Z = normal.
+    _beamMat.makeBasis(_beamRight, _beamDir, _beamNormal);
+    _beamMat.scale(_beamScale.set(width, length, 1));
+    _beamMat.setPosition(
+      this.p2pOrigin.x + _beamDir.x * length * 0.5,
+      this.p2pOrigin.y + _beamDir.y * length * 0.5,
+      this.p2pOrigin.z + _beamDir.z * length * 0.5
+    );
+
+    this.obj.matrix.copy(_beamMat);
+    this.obj.matrixWorldNeedsUpdate = true;   // matrixAutoUpdate is off — flag it manually
+  }
+
   /** Release GPU resources */
   dispose() {
     this.tex.dispose();
     this.mat.dispose();
+    if (this.isLinkedP2P) this.obj.geometry.dispose();   // per-particle PlaneGeometry, not shared
     this.alive = false;
   }
 }
+
+// Scratch objects for _updateBeamTransform() — avoids per-frame/per-particle
+// allocation (same pattern as animation.js's CPU-skinning scratch objects).
+const _beamDir    = new THREE.Vector3();
+const _beamToCam  = new THREE.Vector3();
+const _beamRight  = new THREE.Vector3();
+const _beamNormal = new THREE.Vector3();
+const _beamUp     = new THREE.Vector3(0, 1, 0);
+const _beamScale  = new THREE.Vector3();
+const _beamMat    = new THREE.Matrix4();
 
 
 // ─────────────────────────────────────────────
@@ -355,6 +456,13 @@ function evalKey1D(keys, t) {
 // ─────────────────────────────────────────────
 //  NWNEmitter  —  particle pool and spawn logic
 // ─────────────────────────────────────────────
+// p2p=1 + render=Linked (e.g. lightning bolts) render as a single beam quad
+// stretched between the emitter and its P2P target — see NWNParticle's
+// isLinkedP2P branch and _updateBeamTransform().
+function _isLinkedP2P(node) {
+  return !!node.p2p && (node.renderMode || '').toLowerCase() === 'linked';
+}
+
 class NWNEmitter {
   /** @param {object} node – Parsed emitter node object */
   constructor(node) {
@@ -381,8 +489,9 @@ class NWNEmitter {
     }
     // Particle count = birthrate × lifeExp + buffer
     const maxAlive = Math.ceil(maxBirthrate * node.lifeExp) + 6;
+    const isLinkedP2P = _isLinkedP2P(node);
     for (let i = 0; i < maxAlive; i++) {
-      const p = new NWNParticle(this.baseTex, node.xgrid, node.ygrid, node.renderMode);
+      const p = new NWNParticle(this.baseTex, node.xgrid, node.ygrid, node.renderMode, isLinkedP2P);
       scene.add(p.obj);
       this.pool.push(p);
     }
@@ -552,7 +661,7 @@ class NWNEmitter {
     // Take from pool or create a new particle
     let p = this.pool.pop();
     if (!p) {
-      p = new NWNParticle(this.baseTex, this.node.xgrid, this.node.ygrid, this.node.renderMode);
+      p = new NWNParticle(this.baseTex, this.node.xgrid, this.node.ygrid, this.node.renderMode, _isLinkedP2P(this.node));
       scene.add(p.obj);
     }
     const { emitDir, localX, localY } = this._getWorldAxes();

--- a/js/emitter.js
+++ b/js/emitter.js
@@ -93,6 +93,9 @@ class NWNParticle {
     // Movement vectors (world space)
     this.vx = 0; this.vy = 0; this.vz = 0;
 
+    // Point-to-point destination (space), set by spawn(); null = normal flight
+    this.p2pTarget = null;
+
     // Sprite rotation (cumulative, rad) — for particleRot
     this.rotation = 0;
 
@@ -109,11 +112,12 @@ class NWNParticle {
    * @param {THREE.Vector3} localY    – Local +Y axis in world space (for ysize spread)
    */
   spawn(worldPos, node, emitDir, localX, localY) {
-    this.node       = node;
-    this.age        = 0;
-    this.alive      = true;
-    this.rotation   = 0;
+    this.node        = node;
+    this.age         = 0;
+    this.alive       = true;
+    this.rotation    = 0;
     this.obj.visible = true;
+    this.p2pTarget   = p2pTarget;
 
     // ── Emitter direction ────────────────────────────────────────────
     const dir = (emitDir && emitDir.lengthSq() > 0.01)
@@ -193,23 +197,64 @@ class NWNParticle {
     this.obj.position.y += this.vy * dt;
     this.obj.position.z += this.vz * dt;
 
-    // NWN gravity: the Aurora engine scales 'mass' by gravitational acceleration.
-    // mass=1.0 → particle falls at ~9.81 NWN units/s² (Earth gravity).
-    // mass=0.32 → eff. 3.14/s² → apex at t≈0.23s, particle reaches
-    // ground (Δy≈−3.9) after t≈1.7s — produces the visible arc. ✓
-    const NWN_G = 9.81;
-    if (node.mass) {
-      this.vy -= node.mass * NWN_G * dt;
-    }
+    if (this.p2pTarget) {
+      // ── Point-to-Point (Gravity) physics ──────────────────────────────
+      // p2p_sel=0: Instead of normal gravity, the particle is pulled toward
+      // the target point (Reference Node). According to NWN documentation,
+      // 'grav' is a direct acceleration (m/s²) toward the target, and
+      // 'threshold' is the deletion radius around the target ("Event
+      // Horizon"). 'drag' is documented only qualitatively ("overshoots
+      // the target, then turns back — higher value = greater overshoot"),
+      // with no published formula; here, it is approximated as a velocity
+      // boost that produces exactly this overshoot behavior.
+      // ponytail: p2p_sel=1 (Bezier path) uses the same approximation;
+      // true Bezier tangents (p2p_bezier2/3) are not evaluated — this is
+      // the place to implement them if needed (e.g., for lightning emitters).
+      const dx = this.p2pTarget.x - this.obj.position.x;
+      const dy = this.p2pTarget.y - this.obj.position.y;
+      const dz = this.p2pTarget.z - this.obj.position.z;
+      const dist = Math.sqrt(dx*dx + dy*dy + dz*dz);
 
-    // Drag: exponential deceleration — simulates air resistance
-    // Formula: v *= (1 - drag)^dt  ≈  v * e^(-drag * dt)
-    const drag = node.drag || 0;
-    if (drag > 0) {
-      const damping = Math.pow(Math.max(1 - drag, 0), dt);
-      this.vx *= damping;
-      this.vy *= damping;
-      this.vz *= damping;
+      if (node.threshold > 0 && dist < node.threshold) {
+        this.alive = false;
+        this.obj.visible = false;
+        return false;
+      }
+
+      if (dist > 1e-5) {
+        const grav = node.grav || 0;
+        const invDist = 1 / dist;
+        this.vx += dx * invDist * grav * dt;
+        this.vy += dy * invDist * grav * dt;
+        this.vz += dz * invDist * grav * dt;
+      }
+
+      const drag = node.drag || 0;
+      if (drag > 0) {
+        const boost = 1 + drag * dt;
+        this.vx *= boost;
+        this.vy *= boost;
+        this.vz *= boost;
+      }
+    } else {
+      // NWN gravity: the Aurora engine scales 'mass' by gravitational acceleration.
+      // mass=1.0 → particle falls at ~9.81 NWN units/s² (Earth gravity).
+      // mass=0.32 → eff. 3.14/s² → apex at t≈0.23s, particle reaches
+      // ground (Δy≈−3.9) after t≈1.7s — produces the visible arc. ✓
+      const NWN_G = 9.81;
+      if (node.mass) {
+        this.vy -= node.mass * NWN_G * dt;
+      }
+
+      // Drag: exponential deceleration — simulates air resistance
+      // Formula: v *= (1 - drag)^dt  ≈  v * e^(-drag * dt)
+      const drag = node.drag || 0;
+      if (drag > 0) {
+        const damping = Math.pow(Math.max(1 - drag, 0), dt);
+        this.vx *= damping;
+        this.vy *= damping;
+        this.vz *= damping;
+      }
     }
 
     // Sprite rotation: particleRot = angular velocity in rad/s
@@ -454,6 +499,16 @@ class NWNEmitter {
     };
   }
 
+  /** World position of the P2P target reference node, or null if not configured. */
+  _getP2PTargetWorldPos() {
+    if (!this.node._p2pTargetName) return null;
+    const obj = nodeObjects[this.node._p2pTargetName];
+    if (!obj) return null;
+    const pos = new THREE.Vector3();
+    obj.getWorldPosition(pos);
+    return pos;
+  }
+
   /** Call once per frame */
   update(dt) {
     if (!this.baseTex) return;
@@ -501,7 +556,8 @@ class NWNEmitter {
       scene.add(p.obj);
     }
     const { emitDir, localX, localY } = this._getWorldAxes();
-    p.spawn(this._getWorldPos(), this.node, emitDir, localX, localY);
+    const p2pTarget = this.node.p2p ? this._getP2PTargetWorldPos() : null;
+    p.spawn(this._getWorldPos(), this.node, emitDir, localX, localY, p2pTarget);
     this.active.push(p);
   }
 

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -168,6 +168,7 @@ const I18N_BUNDLE = {
     log_em_init_pending:  ' (texture pending: "{tex}")',
     log_em_error:         '[Emitter] "{name}" error: {msg}',
     log_em_tex_pending:   '(texture pending: "{tex}")',
+    log_em_lightning_static: ' [lightning, static beam]',
     // multipart msg
     log_multi_part:       'Multi-Part assembly: "{part}" merged into "{base}"',
     log_char_part:        'Character assembly: "{part}" merged into "{base}"',
@@ -382,6 +383,7 @@ const I18N_BUNDLE = {
     // Log-Meldungen
     log_em_init:          '[Emitter] "{name}" initialisiert',
     log_em_init_pending:  ' (Textur ausstehend: "{tex}")',
+    log_em_lightning_static: ' [Lightning, statischer Strahl]',
     log_em_error:         '[Emitter] "{name}" Fehler: {msg}',
     log_em_tex_pending:   '(Textur ausstehend: "{tex}")',
     // multipart msg

--- a/js/parser.js
+++ b/js/parser.js
@@ -293,6 +293,9 @@ function parseNode(lines, start) {
     spread:     0,
     grav:       0,
     drag:       0,
+    p2p:        0,     // NEW — 1 = Point-to-Point-Emitter (drags particles to a reference node)
+    p2pSel:     0,     // NEW — 0 = Gravity, 1 = Bezier (Bezier falls back on Gravity for the time being)
+    threshold:  0,     // NEW — P2P: Deletion radius around the target point ("Event Horizon")
     fps:        0,
     frameStart: 0,
     frameEnd:   0,
@@ -382,6 +385,9 @@ function parseNode(lines, start) {
     else if (k === 'spread')            node.spread     = num(t[1]);
     else if (k === 'grav')              node.grav       = num(t[1]);
     else if (k === 'drag')              node.drag       = num(t[1]);
+    else if (k === 'p2p')               node.p2p        = parseInt(t[1]) || 0;
+    else if (k === 'p2p_sel')           node.p2pSel     = parseInt(t[1]) || 0;
+    else if (k === 'threshold')         node.threshold  = num(t[1]);
     else if (k === 'fps')               node.fps        = num(t[1]);
     else if (k === 'framestart')        node.frameStart = parseInt(t[1]) || 0;
     else if (k === 'frameend')          node.frameEnd   = parseInt(t[1]) || 0;

--- a/js/parser.js
+++ b/js/parser.js
@@ -112,6 +112,7 @@ function parseFullAnimNode(lines, start) {
     alphastart: 1, alphamid: 1, alphaend: 1,
     sizestart: 1, sizemid: 0, sizeend: 1,
     colorstart: 3, colormid: 3, colorend: 3,
+    selfillumcolor: 3,   // NEW — für selfillumcolorkey / selfillumcolorbezierkey
   };
 
   // Every keyword (non-numeric token) ends the current data block.
@@ -157,6 +158,33 @@ function parseFullAnimNode(lines, start) {
       const count = (t.length > 1 && !isNaN(parseInt(t[1]))) ? parseInt(t[1]) : 0;
       const res = readAllKeys(i + 1, 1, count);
       data.scaleKeys = res.keys.map(k => ({ t: k.t, s: k.vals[0] }));
+      i = res.next;
+      continue;
+    } else if (k === 'positionbezierkey') {
+      // value(3) + tangentIn(3) + tangentOut(3) = 9 Floats/Key
+      const count = (t.length > 1 && !isNaN(parseInt(t[1]))) ? parseInt(t[1]) : 0;
+      const res = readAllKeys(i + 1, 9, count);
+      data.posKeys = res.keys.map(k => ({ t: k.t, x: k.vals[0], y: k.vals[1], z: k.vals[2] }));
+      i = res.next;
+      continue;
+    } else if (k === 'scalebezierkey') {
+      // value(1) + tangentIn(1) + tangentOut(1) = 3 Floats/Key
+      const count = (t.length > 1 && !isNaN(parseInt(t[1]))) ? parseInt(t[1]) : 0;
+      const res = readAllKeys(i + 1, 3, count);
+      data.scaleKeys = res.keys.map(k => ({ t: k.t, s: k.vals[0] }));
+      i = res.next;
+      continue;
+    } else if (k.endsWith('bezierkey')) {
+      // ── Generic Bezier Controller Key (alphabezierkey, selfillumcolorbezierkey, …) ──
+      // Format: <baseName>bezierkey <count>
+      //           <time> <value...> <tangentIn...> <tangentOut...>
+      // Only the value portion is adopted — the viewer interpolates linearly,
+      // not cubic; therefore, the tangents are discarded rather than misinterpreted.
+      const baseName = k.slice(0, -9);   // 'alphabezierkey' → 'alpha'
+      const baseCols = EMITTER_KEY_COLS[baseName] ?? 1;
+      const count = (t.length > 1 && !isNaN(parseInt(t[1]))) ? parseInt(t[1]) : 0;
+      const res = readAllKeys(i + 1, baseCols * 3, count);
+      data.emitterKeys[baseName] = res.keys.map(kk => ({ t: kk.t, vals: kk.vals.slice(0, baseCols) }));
       i = res.next;
       continue;
     } else if (k.endsWith('key')) {

--- a/js/scene.js
+++ b/js/scene.js
@@ -72,6 +72,7 @@ let nodeObjects = {};    // name -> THREE.Object3D
 let selectedNodeName = null;
 let wireOpacity = 0;
 let meshOpacity = 1.0;
+let selectionHighlight = null;
 
 // Name of the supermodel still expected (null = none pending)
 let pendingSupermodel = null;
@@ -299,6 +300,9 @@ canvas.addEventListener('click', e => {
     selectNode(obj.name);
     return;
   }
+  
+  // Ctrl+Click hit nothing selectable → deselect (empty space, floor, grid, etc.)
+  if (typeof closeNodeDetail === 'function') closeNodeDetail();
 });
 
 // ─────────────────────────────────────────────

--- a/js/session.js
+++ b/js/session.js
@@ -118,6 +118,7 @@ function clearSession(keepTextures = false) {
   // 3. Reset internal states
   nodeObjects        = {};
   selectedNodeName   = null;
+  selectionHighlight = null;
   currentModel       = null;
   pendingSupermodel  = null;
   animState.current  = null;

--- a/js/ui.js
+++ b/js/ui.js
@@ -165,14 +165,44 @@ function nodeVisUpdateTypeButtons() {
   });
 }
 
+// ─────────────────────────────────────────────
+//  Selection Highlight — static white Outline-Mesh
+// ─────────────────────────────────────────────
+function clearSelectionHighlight() {
+  if (!selectionHighlight) return;
+  if (selectionHighlight.parent) selectionHighlight.parent.remove(selectionHighlight);
+  selectionHighlight.material.dispose();
+  selectionHighlight = null;
+}
+
+function addSelectionHighlight(obj) {
+  clearSelectionHighlight();
+  if (!obj || !obj.isMesh || !obj.geometry) return;   // only Trimesh/Skin/Dangly/Animmesh
+  const mat = new THREE.MeshBasicMaterial({
+    color:       0xffffff,
+    side:        THREE.BackSide,
+    depthWrite:  false,
+    transparent: true,
+    opacity:     0.6,
+  });
+  // Same geometry reference as the original — thus follows automatically
+  // CPU skinning/dangly mesh deformation without custom update logic.
+  const mesh = new THREE.Mesh(obj.geometry, mat);
+  mesh.scale.setScalar(1.03);
+  mesh.userData.isSelectionHighlight = true;
+  obj.add(mesh);
+  selectionHighlight = mesh;
+}
+
 function selectNode(name) {
   selectedNodeName = name;
   document.querySelectorAll('.node-item').forEach(el => el.classList.remove('selected'));
   const el = document.querySelector(`.node-item[data-name="${CSS.escape(name)}"]`);
   if (el) { el.classList.add('selected'); el.scrollIntoView({ block: 'nearest' }); }
 
-  const obj = nodeObjects[name];
-  if (!obj || !obj.userData.nodeData) { document.getElementById('node-detail').style.display = 'none'; return; }
+const obj = nodeObjects[name];
+  if (!obj || !obj.userData.nodeData) { document.getElementById('node-detail').style.display = 'none'; clearSelectionHighlight(); return; }
+  addSelectionHighlight(obj);
   const n = obj.userData.nodeData;
 
   const detail = document.getElementById('node-detail');
@@ -987,6 +1017,7 @@ if (document.readyState === 'loading') {
     if (panel) panel.style.display = 'none';
     document.querySelectorAll('.node-item').forEach(el => el.classList.remove('selected'));
     if (typeof selectedNodeName !== 'undefined') selectedNodeName = null;
+    clearSelectionHighlight();
   }
   window.closeNodeDetail    = closeNodeDetail;
   window.initNodeDetailDrag = initNodeDetailDrag;

--- a/lang/de.json
+++ b/lang/de.json
@@ -193,6 +193,7 @@
   "log_em_init_pending": " (Textur ausstehend: \"{tex}\")",
   "log_em_tex_pending": "(Textur ausstehend: \"{tex}\")",
   "log_em_error": "[Emitter] \"{name}\" Fehler: {msg}",
+  "log_em_lightning_static": " [Lightning, statischer Strahl]",
   "log_multi_part": "Multi-Part-Assembly: \"{part}\" → \"{base}\" zusammengeführt",
   "log_char_part": "Charakter-Assembly: \"{part}\" → \"{base}\" zusammengeführt",
   "log_char_assembly": "Multi-Part Modell wird geladen...",

--- a/lang/en.json
+++ b/lang/en.json
@@ -193,6 +193,7 @@
   "log_em_init_pending": " (texture pending: \"{tex}\")",
   "log_em_tex_pending": "(texture pending: \"{tex}\")",
   "log_em_error": "[Emitter] \"{name}\" error: {msg}",
+  "log_em_lightning_static": " [lightning, static beam]",
   "log_multi_part": "Multi-Part assembly: \"{part}\" merged into \"{base}\"",
   "log_char_part": "Character assembly: \"{part}\" merged into \"{base}\"",
   "log_char_assembly": "Multi-Part model loading...",


### PR DESCRIPTION
A small feature has been added that applies a subtle highlight to a mesh in the 3D viewport when you Ctrl-click it. The same applies to nodes in the scene graph: clicking a node highlights the corresponding mesh in the 3D viewport. This highlight is removed by closing the node inspector window or clicking inside the 3D viewport.
However, the primary addition is support for point-to-point (P2P) and linked P2P effects for emitters.